### PR TITLE
백엔드에서 클라이언트를 구분하고 전송할 종목을 저장

### DIFF
--- a/back/src/interfaces/socketRequest.ts
+++ b/back/src/interfaces/socketRequest.ts
@@ -1,0 +1,4 @@
+export interface ISocketRequest {
+	type: string;
+	stock?: string;
+}

--- a/back/src/loaders/socket.ts
+++ b/back/src/loaders/socket.ts
@@ -35,16 +35,16 @@ export default (app: express.Application): void => {
 	}, 1000);
 
 	webSocketServer.on('connection', (ws, req) => {
-		const clientIP =
-			req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-
 		ws.on('message', (message: string) => {
 			const requestData: ISocketRequest = translateRequestFormat(
 				message,
 			) || { type: 'error' };
-			if (requestData.type === 'visited') {
+			if (requestData.type === 'open') {
 				socketClientMap.set(ws, requestData.stock);
 			}
+		});
+		ws.on('close', () => {
+			socketClientMap.delete(ws);
 		});
 	});
 };

--- a/back/src/loaders/socket.ts
+++ b/back/src/loaders/socket.ts
@@ -3,8 +3,20 @@ import express from 'express';
 import Logger from './logger';
 
 import { IStockInformation } from '../interfaces/stockInformation';
+import { ISocketRequest } from '../interfaces/socketRequest';
 
-const translateSocketData = (data) => JSON.stringify(data);
+const socketClientMap = new Map();
+const stockInformation: Map<string, IStockInformation> = new Map([
+	[
+		'Boostock',
+		{
+			name: 'Boostock',
+			current: 3000,
+		},
+	],
+]);
+const translateRequestFormat = (data) => JSON.parse(data);
+const translateResponseFormat = (data) => JSON.stringify(data);
 
 export default (app: express.Application): void => {
 	const HTTPServer = app.listen(3333, () => {
@@ -12,17 +24,27 @@ export default (app: express.Application): void => {
 	});
 
 	const webSocketServer = new wsModule.Server({ server: HTTPServer });
-	const broadcast = (message: string) => {
-		webSocketServer.clients.forEach((client) => {
-			client.send(message);
+	const broadcast = (clients) => {
+		clients.forEach((stock, client) => {
+			const response = stockInformation.get(stock);
+			client.send(translateResponseFormat(response));
 		});
 	};
-
 	setInterval(() => {
-		const message: IStockInformation = {
-			name: 'Boostock',
-			current: 3000,
-		};
-		broadcast(translateSocketData(message));
+		broadcast(socketClientMap);
 	}, 1000);
+
+	webSocketServer.on('connection', (ws, req) => {
+		const clientIP =
+			req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+
+		ws.on('message', (message: string) => {
+			const requestData: ISocketRequest = translateRequestFormat(
+				message,
+			) || { type: 'error' };
+			if (requestData.type === 'visited') {
+				socketClientMap.set(ws, requestData.stock);
+			}
+		});
+	});
 };

--- a/front/src/pages/trade/Trade.tsx
+++ b/front/src/pages/trade/Trade.tsx
@@ -5,6 +5,12 @@ import BidAsk from './bidAsk/BidAsk';
 import './Trade.scss';
 
 // interface Props {}
+interface IRequestStock {
+	type: string;
+	stock: string;
+}
+
+const translateSocketData = (data: object | []) => JSON.stringify(data);
 
 const info: Info = {
 	name: '호눅스 코인',
@@ -17,6 +23,15 @@ const info: Info = {
 };
 
 const Trade = () => {
+	const webSocket = new WebSocket(process.env.WEBSOCKET || '');
+	webSocket.onopen = () => {
+		const data: IRequestStock = { type: 'visited', stock: 'Boostock' };
+		webSocket.send(translateSocketData(data));
+	};
+	webSocket.onmessage = (event) => {};
+	webSocket.onclose = () => {};
+	webSocket.onerror = (event) => {};
+
 	return (
 		<main className="trade">
 			<section className="trade-container">

--- a/front/src/pages/trade/Trade.tsx
+++ b/front/src/pages/trade/Trade.tsx
@@ -5,9 +5,9 @@ import BidAsk from './bidAsk/BidAsk';
 import './Trade.scss';
 
 // interface Props {}
-interface IRequestStock {
+interface IConnection {
 	type: string;
-	stock: string;
+	stock?: string;
 }
 
 const translateSocketData = (data: object | []) => JSON.stringify(data);
@@ -25,11 +25,11 @@ const info: Info = {
 const Trade = () => {
 	const webSocket = new WebSocket(process.env.WEBSOCKET || '');
 	webSocket.onopen = () => {
-		const data: IRequestStock = { type: 'visited', stock: 'Boostock' };
+		const data: IConnection = { type: 'open', stock: 'Boostock' };
 		webSocket.send(translateSocketData(data));
 	};
-	webSocket.onmessage = (event) => {};
 	webSocket.onclose = () => {};
+	webSocket.onmessage = (event) => {};
 	webSocket.onerror = (event) => {};
 
 	return (


### PR DESCRIPTION
클라이언트가 종목 상세 정보 접속시 소켓 서버에 지정한 종목 정보를 전송합니다
서버는 클라이언트를 구분하고 전송할 종목을 Map에 저장합니다
클라이언트가 접속 종료 이벤트 발생 시 접속 유저 Map에서 삭제합니다.