### PR TITLE
종목 정보 일별 데이터 반영, 매수/매도 API 복구, 주문 요청 Auctioneer API에게 전달

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -20,7 +20,7 @@
                 "mongoose": "^6.0.12",
                 "morgan": "^1.10.0",
                 "mysql": "^2.18.1",
-                "node-fetch": "^3.0.0",
+                "node-fetch": "^2.6.6",
                 "pm2": "^5.1.2",
                 "reflect-metadata": "^0.1.13",
                 "ts-node": "^10.4.0",
@@ -2891,27 +2891,6 @@
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
             "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
         },
-        "node_modules/fetch-blob": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-            "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "dependencies": {
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20 || >= 14.13"
-            }
-        },
         "node_modules/figlet": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.2.tgz",
@@ -4659,19 +4638,33 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-            "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
+            "version": "2.6.6",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
             "dependencies": {
-                "data-uri-to-buffer": "^3.0.1",
-                "fetch-blob": "^3.1.2"
+                "whatwg-url": "^5.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
+                "node": "4.x || >=6.0.0"
+            }
+        },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/nodemon": {
@@ -7056,14 +7049,6 @@
             },
             "engines": {
                 "node": ">=6.0"
-            }
-        },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-            "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q==",
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/webidl-conversions": {
@@ -9577,14 +9562,6 @@
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
             "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
         },
-        "fetch-blob": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-            "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-            "requires": {
-                "web-streams-polyfill": "^3.0.3"
-            }
-        },
         "figlet": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.2.tgz",
@@ -10900,12 +10877,32 @@
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
         },
         "node-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-            "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
+            "version": "2.6.6",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
             "requires": {
-                "data-uri-to-buffer": "^3.0.1",
-                "fetch-blob": "^3.1.2"
+                "whatwg-url": "^5.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
+                }
             }
         },
         "nodemon": {
@@ -12627,11 +12624,6 @@
             "version": "3.9.5",
             "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
             "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng=="
-        },
-        "web-streams-polyfill": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-            "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
         },
         "webidl-conversions": {
             "version": "6.1.0",

--- a/back/package.json
+++ b/back/package.json
@@ -45,7 +45,7 @@
         "mongoose": "^6.0.12",
         "morgan": "^1.10.0",
         "mysql": "^2.18.1",
-        "node-fetch": "^3.0.0",
+        "node-fetch": "^2.6.6",
         "pm2": "^5.1.2",
         "reflect-metadata": "^0.1.13",
         "ts-node": "^10.4.0",

--- a/back/src/api/order/order.ts
+++ b/back/src/api/order/order.ts
@@ -1,4 +1,6 @@
 import express, { Request, Response } from 'express';
+import fetch from 'node-fetch';
+
 import { Order } from '@models/index';
 import { OrderService } from '@services/index';
 import { CommonError } from '@services/errors/index';
@@ -8,23 +10,25 @@ export default (): express.Router => {
 	const router = express.Router();
 
 	router.post('/', async (req: Request, res: Response) => {
+		const { userId, stockCode, type, amount, price } = req.body;
 		transaction(
-			(queryRunner: QueryRunner, then: () => void, err: (err: CommonError) => void, fin: () => void) => {
+			(queryRunner: QueryRunner, commit: () => void, rollback: (err: CommonError) => void, release: () => void) => {
 				const orderServiceInstance = new OrderService();
 				orderServiceInstance
 					.order(queryRunner.manager, {
-						userId: Number(req.cookies.id) || 0,
-						stockCode: req.body.code,
-						type: Number(req.body.type) || 0,
-						amount: Number(req.body.amount) || 0,
-						price: Number(req.body.price) || 0,
+						userId: Number(1) || 0,
+						stockCode,
+						type: Number(type) || 0,
+						amount: Number(amount) || 0,
+						price: Number(price) || 0,
 					})
 					.then(() => {
 						res.status(200).end();
-						then();
+						commit();
+						fetch(`/api/message/bid?code=${stockCode}`);
 					})
-					.catch(err)
-					.finally(fin);
+					.catch(rollback)
+					.finally(release);
 			},
 			req,
 			res,

--- a/back/src/api/order/order.ts
+++ b/back/src/api/order/order.ts
@@ -25,7 +25,7 @@ export default (): express.Router => {
 					.then(() => {
 						res.status(200).end();
 						commit();
-						fetch(`/api/message/bid?code=${stockCode}`);
+						fetch(`${process.env.AUCTIOINEER_URL}/api/message/bid?code=${stockCode}`);
 					})
 					.catch(rollback)
 					.finally(release);

--- a/back/src/api/stock/stock.ts
+++ b/back/src/api/stock/stock.ts
@@ -4,10 +4,10 @@ import Emitter from '../../helper/eventEmitter';
 export default (): express.Router => {
 	const router = express.Router();
 	router.post('/conclusion', (req: Request, res: Response) => {
-		const { data } = req.body;
+		const msg = req.body;
+		const stockCode = msg.match.code;
+		Emitter.emit('broadcast', { stockCode, msg });
 
-		// 종목 코드 추출 과정 필요
-		Emitter.emit('broadcast', { stockCode: 'HNX', msg: data });
 		res.end();
 	});
 

--- a/back/src/app.ts
+++ b/back/src/app.ts
@@ -4,9 +4,9 @@ import _http from 'http';
 import Logger from '@loaders/logger';
 import loaders from '@loaders/index';
 import config from '@config/index';
-export const app = express();
 
 async function startServer() {
+	const app = express();
 	const http = _http.createServer(app);
 	await loaders({ expressApp: app, http });
 

--- a/back/src/loaders/socket.ts
+++ b/back/src/loaders/socket.ts
@@ -64,9 +64,6 @@ export default (app: express.Application) => {
 				case 'close':
 					socketClientMap.delete(ws);
 					break;
-				case 'reconnect':
-					// 모든 종목 기초 데이터 재전송
-					break;
 				default:
 					ws.send(translateResponseFormat('error', '알 수 없는 오류가 발생했습니다.'));
 			}

--- a/back/src/loaders/socket.ts
+++ b/back/src/loaders/socket.ts
@@ -44,7 +44,7 @@ export default (app: express.Application) => {
 				client.send(translateResponseFormat('update_target', msg));
 			} else {
 				// msg 오브젝트의 데이터에서 aside 바에 필요한 데이터만 골라서 전송
-				client.send(translateResponseFormat('update_stock', msg.data));
+				client.send(translateResponseFormat('update_stock', msg.match));
 			}
 		});
 	};

--- a/back/src/models/Chart.ts
+++ b/back/src/models/Chart.ts
@@ -1,0 +1,38 @@
+/* eslint-disable import/no-cycle */
+import 'reflect-metadata';
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import Stock from './Stock';
+
+@Entity({ name: 'chart' })
+export default class Chart {
+	@PrimaryGeneratedColumn({ name: 'chart_id' })
+	chartId: number;
+
+	@ManyToOne(() => Stock, (stock: Stock) => stock.stockId)
+	@JoinColumn({ name: 'stock_id' })
+	stockId: number;
+
+	@Column()
+	type: number;
+
+	@Column({ name: 'price_before' })
+	priceBefore: number;
+
+	@Column({ name: 'price_start' })
+	priceStart: number;
+
+	@Column({ name: 'price_end' })
+	priceEnd: number;
+
+	@Column({ name: 'price_high' })
+	priceHigh: number;
+
+	@Column({ name: 'price_low' })
+	priceLow: number;
+
+	@Column()
+	amount: number;
+
+	@Column()
+	volume: number;
+}

--- a/back/src/models/Stock.ts
+++ b/back/src/models/Stock.ts
@@ -1,7 +1,9 @@
 import 'reflect-metadata';
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany, JoinColumn } from 'typeorm';
+// eslint-disable-next-line import/no-cycle
+import Chart from './Chart';
 
-@Entity()
+@Entity({ name: 'stock' })
 export default class Stock {
 	@PrimaryGeneratedColumn({ name: 'stock_id' })
 	stockId: number;
@@ -23,4 +25,8 @@ export default class Stock {
 
 	@Column()
 	unit: number;
+
+	@OneToMany(() => Chart, (chart: Chart) => chart.stockId)
+	@JoinColumn({ name: 'charts' })
+	charts: Chart[];
 }

--- a/back/src/models/UserFavorite.ts
+++ b/back/src/models/UserFavorite.ts
@@ -12,6 +12,6 @@ export default class UserFavorite {
 	@JoinColumn({ name: 'user_id' })
 	userId: number;
 
-	@Column()
+	@Column({ name: 'stock_id' })
 	stockId: number;
 }

--- a/back/src/models/index.ts
+++ b/back/src/models/index.ts
@@ -12,3 +12,6 @@ export { default as Stock } from './Stock';
 
 export * from './Order';
 export { default as Order } from './Order';
+
+export * from './Chart';
+export { default as Chart } from './Chart';

--- a/back/src/repositories/StockRepository.ts
+++ b/back/src/repositories/StockRepository.ts
@@ -10,7 +10,7 @@ export default class StockRepository extends Repository<Stock> {
 
 	public async readAllStocks(): Promise<Stock[] | undefined> {
 		return this.find({
-			lock: { mode: 'pessimistic_write' },
+			relations: ['charts'],
 		});
 	}
 

--- a/back/src/services/OrderService.ts
+++ b/back/src/services/OrderService.ts
@@ -107,7 +107,11 @@ export default class OrderService {
 		let resultUpdate = false;
 		if (orderData.type === OrderType.SELL) {
 			const userStockService: UserStockService = new UserStockService();
-			resultUpdate = await userStockService.setAmount(entityManager, user.userId, holdStockAmount - orderData.amount);
+			resultUpdate = await userStockService.setAmount(
+				entityManager,
+				holdStock.userStockId,
+				holdStockAmount - orderData.amount,
+			);
 		} else if (orderData.type === OrderType.BUY) {
 			resultUpdate = await userService.setBalance(entityManager, user.userId, user.balance - totalPrice);
 		}

--- a/back/src/services/StockService.ts
+++ b/back/src/services/StockService.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import { EntityManager } from 'typeorm';
+import { EntityManager, createQueryBuilder } from 'typeorm';
 import { Stock } from '@models/index';
 import { StockRepository } from '@repositories/index';
 import { CommonError, CommonErrorMessage, StockError, StockErrorMessage } from '@services/errors/index';
@@ -41,10 +41,11 @@ export default class StockService {
 
 	public async getStocksCurrent(entityManager: EntityManager): Promise<Stock[]> {
 		const stockRepository: StockRepository = this.getStockRepository(entityManager);
-
 		const allStocks = await stockRepository.readAllStocks();
 		if (!allStocks) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
 
-		return allStocks;
+		return allStocks.map((stock) => {
+			return { ...stock, charts: stock.charts.filter(({ type }) => type === 1440) };
+		});
 	}
 }

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -27,7 +27,6 @@ const startSocket = (setSocket: SetterOrUpdater<WebSocket | null>, setStockList:
 		const { type, data } = translateResponseData(event.data);
 		switch (type) {
 			case 'stocks_info':
-				console.log(data);
 				setStockList(data);
 				break;
 			default:

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -27,6 +27,7 @@ const startSocket = (setSocket: SetterOrUpdater<WebSocket | null>, setStockList:
 		const { type, data } = translateResponseData(event.data);
 		switch (type) {
 			case 'stocks_info':
+				console.log(data);
 				setStockList(data);
 				break;
 			default:

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SetterOrUpdater, useSetRecoilState } from 'recoil';
 import webSocketAtom from '@recoil/websocket/atom';
-import stockListAtom, { IStockListItem } from '@recoil/stockList/atom';
+import stockListAtom, { IStockListItem, IStockChartItem } from '@recoil/stockList/atom';
 import { translateResponseData } from './common/utils/socketUtils';
 
 interface IProps {
@@ -28,6 +28,59 @@ const startSocket = (setSocket: SetterOrUpdater<WebSocket | null>, setStockList:
 		switch (type) {
 			case 'stocks_info':
 				setStockList(data);
+				break;
+			case 'update_stock':
+				setStockList((prev) => {
+					return prev.map((stockItem) => {
+						if (stockItem.code !== data.code) return stockItem;
+
+						const newChartsData: IStockChartItem[] = stockItem.charts.map((chartItem) => {
+							return chartItem.type === 1
+								? chartItem
+								: {
+										...chartItem,
+										volume: chartItem.volume + data.price * data.amount,
+								  };
+						});
+
+						return {
+							...stockItem,
+							price: data.price,
+							amount: data.amount,
+							charts: newChartsData,
+						};
+					});
+				});
+				break;
+			case 'update_target':
+				setStockList((prev) => {
+					return prev.map((stockItem) => {
+						const matchData = data.match;
+						const dailyChartData: IStockChartItem = data.currentChart.filter(
+							({ type: chartType }: IStockChartItem) => chartType === 1440,
+						)[0];
+						if (stockItem.code !== matchData.code) return stockItem;
+
+						const newChartsData = stockItem.charts.map((chartItem) => {
+							return chartItem.type === 1
+								? chartItem
+								: {
+										...chartItem,
+										volume: chartItem.volume + matchData.price * matchData.amount,
+										amount: chartItem.amount + matchData.amount,
+										priceLow: dailyChartData.priceLow,
+										priceHigh: dailyChartData.priceHigh,
+								  };
+						});
+
+						return {
+							...stockItem,
+							price: matchData.price,
+							amount: matchData.amount,
+							charts: newChartsData,
+						};
+					});
+				});
 				break;
 			default:
 		}

--- a/front/src/pages/trade/Trade.tsx
+++ b/front/src/pages/trade/Trade.tsx
@@ -74,7 +74,7 @@ const Trade = () => {
 							<Order />
 						</section>
 						<section className="trade-bid-ask">
-							<BidAsk />
+							<BidAsk stockCode={stockCode} />
 						</section>
 					</section>
 					<section className="trade-conclusion">

--- a/front/src/pages/trade/bidAsk/BidAsk.tsx
+++ b/front/src/pages/trade/bidAsk/BidAsk.tsx
@@ -10,14 +10,14 @@ import './bidask.scss';
 
 interface IOrderData {
 	userId: number;
-	stockId: number;
+	stockCode: string;
 	type: number;
 	option: number;
 	amount: number;
 	price: number;
 }
 
-const BidAsk = () => {
+const BidAsk = ({ stockCode }) => {
 	const [bidAskType, setBidAskType] = useState<string>('매수');
 	const [bidAskOption, setBidAskOption] = useState<string>('지정가');
 	const [bidAskPrice, setBidAskPrice] = useRecoilState(bidAskPriceAtom);
@@ -40,9 +40,9 @@ const BidAsk = () => {
 
 		const orderData: IOrderData = {
 			userId: 1,
-			stockId: 1,
-			type: bidAskType === '매도' ? 0 : 1,
-			option: bidAskOption === '지정가' ? 0 : 1,
+			stockCode,
+			type: bidAskType === '매도' ? 1 : 2,
+			option: bidAskOption === '지정가' ? 1 : 2,
 			amount: bidAskAmount,
 			price: bidAskPrice,
 		};

--- a/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.tsx
+++ b/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.tsx
@@ -15,7 +15,9 @@ export interface Props {
 
 const SideBarItem = (props: Props) => {
 	const { stock, isFavorite } = props;
-	const { code, nameKorean, nameEnglish, price, previousClose, unit } = stock;
+	const { code, nameKorean, price, previousClose, charts } = stock;
+
+	const { volume = 0 } = charts[0] ?? [];
 
 	const percent = ((price - previousClose) / previousClose) * 100;
 	let status = '';
@@ -38,7 +40,7 @@ const SideBarItem = (props: Props) => {
 				<p className="sidebar__item-percent-bottom">{formatNumber(price - previousClose)}</p>
 			</div>
 			<div className="sidebar__item-amount">
-				<p className="sidebar__item-amount-value">{/* {formatNumber(tradingAmount)} */}0</p>
+				<p className="sidebar__item-amount-value">{formatNumber(volume)}</p>
 				<p className="sidebar__item-amount-unit">원</p>
 			</div>
 		</Link>

--- a/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.tsx
+++ b/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.tsx
@@ -17,7 +17,7 @@ const SideBarItem = (props: Props) => {
 	const { stock, isFavorite } = props;
 	const { code, nameKorean, price, previousClose, charts } = stock;
 
-	const { volume = 0 } = charts[0] ?? [];
+	const { volume = 0 } = charts.filter(({ type }) => type === 1440)[0] ?? [];
 
 	const percent = ((price - previousClose) / previousClose) * 100;
 	let status = '';

--- a/front/src/pages/trade/stockInfo/StockInfo.tsx
+++ b/front/src/pages/trade/stockInfo/StockInfo.tsx
@@ -5,7 +5,7 @@ import caretIcon from '@src/common/utils/caretIcon';
 
 import './StockInfo.scss';
 
-interface Props {
+interface IProps {
 	info: IStockListItem;
 }
 
@@ -25,8 +25,9 @@ function formatTradingData(data: number, postfix: string) {
 	return `${formatNumber(Math.round(data / ONE_MILLION))}백만${postfix}`;
 }
 
-const StockInfo = ({ info }: Props) => {
-	const { nameKorean, price, previousClose } = info;
+const StockInfo = ({ info }: IProps) => {
+	const { nameKorean, price, previousClose, charts } = info;
+	const { priceLow = 0, priceHigh = 0, volume = 0, amount = 0 } = charts[0] ?? [];
 
 	const percent = ((price - previousClose) / previousClose) * 100;
 
@@ -52,19 +53,19 @@ const StockInfo = ({ info }: Props) => {
 			</div>
 			<div className="stock-info__right">
 				<div className="extra-info high-price">
-					<span className="extra-info-data">{/* {formatNumber(highPrice)}원 */}0</span>
+					<span className="extra-info-data">{formatNumber(priceHigh)}원</span>
 					<span className="extra-info-text">고가</span>
 				</div>
 				<div className="extra-info low-price">
-					<span className="extra-info-data">{/* {formatNumber(lowPrice)}원 */}0</span>
+					<span className="extra-info-data">{formatNumber(priceLow)}원</span>
 					<span className="extra-info-text">저가</span>
 				</div>
 				<div className="extra-info trading-volume">
-					<span className="extra-info-data">{/* {formatTradingData(tradingVolume, '주')} */}0</span>
+					<span className="extra-info-data">{formatTradingData(amount, '주')}</span>
 					<span className="extra-info-text">거래량</span>
 				</div>
 				<div className="extra-info trading-amount">
-					<span className="extra-info-data">{/* {formatTradingData(tradingAmount, '원')} */}0</span>
+					<span className="extra-info-data">{formatTradingData(volume, '원')}</span>
 					<span className="extra-info-text">거래대금</span>
 				</div>
 			</div>

--- a/front/src/pages/trade/stockInfo/StockInfo.tsx
+++ b/front/src/pages/trade/stockInfo/StockInfo.tsx
@@ -27,7 +27,7 @@ function formatTradingData(data: number, postfix: string) {
 
 const StockInfo = ({ info }: IProps) => {
 	const { nameKorean, price, previousClose, charts } = info;
-	const { priceLow = 0, priceHigh = 0, volume = 0, amount = 0 } = charts[0] ?? [];
+	const { priceLow = 0, priceHigh = 0, volume = 0, amount = 0 } = charts.filter(({ type }) => type === 1440)[0] ?? [];
 
 	const percent = ((price - previousClose) / previousClose) * 100;
 

--- a/front/src/recoil/stockList/atom.ts
+++ b/front/src/recoil/stockList/atom.ts
@@ -1,5 +1,17 @@
 import { atom } from 'recoil';
 
+export interface IStockChartItem {
+	chartId: number;
+	type: number;
+	priceBefore: number;
+	priceStart: number;
+	priceEnd: number;
+	priceLow: number;
+	priceHigh: number;
+	volume: number;
+	amount: number;
+}
+
 export interface IStockListItem {
 	stockId: number;
 	code: string;
@@ -8,6 +20,7 @@ export interface IStockListItem {
 	price: number;
 	previousClose: number;
 	unit: number;
+	charts: IStockChartItem[];
 }
 
 const stockListAtom = atom<IStockListItem[]>({

--- a/front/src/recoil/stockList/index.ts
+++ b/front/src/recoil/stockList/index.ts
@@ -1,6 +1,6 @@
 import atom from './atom';
-import type { IStockListItem } from './atom';
+import type { IStockChartItem, IStockListItem } from './atom';
 
-export { IStockListItem };
+export { IStockChartItem, IStockListItem };
 
 export default atom;


### PR DESCRIPTION
1. 클라이언트가 소켓에 접속 시 받는 종목 정보에 일별 데이터(실시간 차트) 정보를 Join하여 전송합니다.
    - 전송받은 일별 데이터를 store에 저장하여 Trade 컴포넌트를 리렌더링합니다
    - 가격, 거래대금, 고가, 저가, 등
  
2. 매수/매도 API 복구
    - 종목 코드에 맞춰 매수/매도 주문을 합니다
3. DB에 주문 요청이 정상적으로 저장되면 Autioneer API에게 새로운 주문 처리를 호출합니다
