### PR TITLE
체결 로직의 잘못 설정된 값 수정

### DIFF
--- a/auctioneer/src/services/AuctioneerService.ts
+++ b/auctioneer/src/services/AuctioneerService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import { getConnection } from 'typeorm';
-import { UserRepository, UserStockRepository, OrderRepository, ChartRepository } from '@repositories/index';
+import { StockRepository, UserRepository, UserStockRepository, OrderRepository, ChartRepository } from '@repositories/index';
 import { UserStock, OrderType } from '@models/index';
 import BidAskTransaction, { ITransactionLog } from './BidAskTransaction';
 import { OrderError, OrderErrorMessage } from './errors';
@@ -22,29 +22,34 @@ export default class AuctioneerService {
 		await queryRunner.connect();
 		await queryRunner.startTransaction();
 		try {
-			const OrderRepositoryRunner = queryRunner.manager.getCustomRepository(OrderRepository);
-			const UserStockRepositoryRunner = queryRunner.manager.getCustomRepository(UserStockRepository);
+			const StockRepositoryRunner = queryRunner.manager.getCustomRepository(StockRepository);
 			const UserRepositoryRunner = queryRunner.manager.getCustomRepository(UserRepository);
+			const UserStockRepositoryRunner = queryRunner.manager.getCustomRepository(UserStockRepository);
+			const OrderRepositoryRunner = queryRunner.manager.getCustomRepository(OrderRepository);
 			const ChartRepositoryRunner = queryRunner.manager.getCustomRepository(ChartRepository);
 
-			const orderAsk = await OrderRepositoryRunner.readOrderByDesc(stockId, OrderType.SELL);
+			const stock = await StockRepositoryRunner.readStockById(stockId);
+			if (stock === undefined) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
+
+			const orderAsk = await OrderRepositoryRunner.readOrderByDesc(stockId, OrderType.BUY);
 			if (orderAsk === undefined || orderAsk.amount <= 0) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
 
-			const orderBid = await OrderRepositoryRunner.readOrderByDesc(stockId, OrderType.BUY);
+			const orderBid = await OrderRepositoryRunner.readOrderByAsc(stockId, OrderType.SELL);
 			if (orderBid === undefined || orderBid.amount <= 0) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
 
-			if (orderBid.price < orderAsk.price) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
+			if (orderBid.price > orderAsk.price) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
 
 			const task = new BidAskTransaction(
-				OrderRepositoryRunner,
+				StockRepositoryRunner,
 				UserRepositoryRunner,
 				UserStockRepositoryRunner,
+				OrderRepositoryRunner,
 				ChartRepositoryRunner,
 			);
 
 			const transactionLog: ITransactionLog = {
 				code,
-				price: orderAsk.price,
+				price: orderBid.price,
 				amount: Math.min(orderBid.amount, orderAsk.amount),
 				createdAt: new Date().getTime(),
 			};
@@ -53,17 +58,17 @@ export default class AuctioneerService {
 
 			const askUser = await UserRepositoryRunner.readUserById(orderAsk.userId);
 			if (askUser === undefined) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
-			const askUserStock = askUser.stocks.find((stock: UserStock) => stock.stockId === stockId);
+			const askUserStock = askUser.stocks.find((userStock: UserStock) => userStock.stockId === stockId);
 
 			const bidUser = await UserRepositoryRunner.readUserById(orderBid.userId);
 			if (bidUser === undefined) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
-			const bidUserStock = bidUser.stocks.find((stock: UserStock) => stock.stockId === stockId);
+			const bidUserStock = bidUser.stocks.find((userStock: UserStock) => userStock.stockId === stockId);
 
 			await Promise.all([
 				task.bidOrderProcess(bidUser, bidUserStock, orderBid),
 				task.askOrderProcess(askUser, askUserStock, orderAsk),
 			]);
-			await task.noticeProcess();
+			await task.noticeProcess(stock);
 			queryRunner.commitTransaction();
 			result = true;
 		} catch (err) {


### PR DESCRIPTION
1. 매도 주문, 매수 주문을 반대로 가져왔던 부분 수정
2. 매도 주문가를 내림차순으로 가져왔던 부분을 오름차순으로 가져오도록 수정
3. 예외처리 조건을 '매도 주문가가 매수 주문가보다 낮을때'에서 '매도 주문가가 매수 주문가보다 높을때'로 변경
4. 체결 금액을 매수 주문가를 기준으로 하였던 것을 매도 주문가를 기준으로 하도록 수정