### PR TITLE
feat: 데모 전 기능 점검 및 사소한 수정

### DIFF
--- a/auctioneer/src/repositories/OrderRepository.ts
+++ b/auctioneer/src/repositories/OrderRepository.ts
@@ -22,7 +22,7 @@ export default class OrderRepository extends Repository<Order> {
 				amount: MoreThan(0),
 				status: OrderStatus.PENDING,
 			},
-			order: { price: 'ASC', createdAt: 'DESC' },
+			order: { price: 'ASC', createdAt: 'ASC' },
 			lock: { mode: 'pessimistic_write' },
 		});
 	}
@@ -35,7 +35,7 @@ export default class OrderRepository extends Repository<Order> {
 				amount: MoreThan(0),
 				status: OrderStatus.PENDING,
 			},
-			order: { price: 'DESC', createdAt: 'DESC' },
+			order: { price: 'DESC', createdAt: 'ASC' },
 			lock: { mode: 'pessimistic_write' },
 		});
 	}

--- a/auctioneer/src/services/AuctioneerService.ts
+++ b/auctioneer/src/services/AuctioneerService.ts
@@ -37,7 +37,7 @@ export default class AuctioneerService {
 			const orderBid = await OrderRepositoryRunner.readOrderByAsc(stockId, OrderType.SELL);
 			if (orderBid === undefined || orderBid.amount <= 0) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
 
-			if (orderBid.price > orderAsk.price) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
+			if (orderBid.price < orderAsk.price) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
 
 			const task = new BidAskTransaction(
 				StockRepositoryRunner,

--- a/auctioneer/src/services/AuctioneerService.ts
+++ b/auctioneer/src/services/AuctioneerService.ts
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import { getConnection } from 'typeorm';
 import { StockRepository, UserRepository, UserStockRepository, OrderRepository, ChartRepository } from '@repositories/index';
-import { UserStock, OrderType } from '@models/index';
+import { UserStock, OrderType, Stock, Order } from '@models/index';
 import BidAskTransaction, { ITransactionLog } from './BidAskTransaction';
 import { OrderError, OrderErrorMessage } from './errors';
 
@@ -28,16 +28,14 @@ export default class AuctioneerService {
 			const OrderRepositoryRunner = queryRunner.manager.getCustomRepository(OrderRepository);
 			const ChartRepositoryRunner = queryRunner.manager.getCustomRepository(ChartRepository);
 
-			const stock = await StockRepositoryRunner.readStockById(stockId);
-			if (stock === undefined) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
+			const [stock, orderAsk, orderBid]: [Stock | undefined, Order | undefined, Order | undefined] = await Promise.all([
+				StockRepositoryRunner.readStockById(stockId),
+				OrderRepositoryRunner.readOrderByDesc(stockId, OrderType.BUY),
+				OrderRepositoryRunner.readOrderByAsc(stockId, OrderType.SELL),
+			]);
 
-			const orderAsk = await OrderRepositoryRunner.readOrderByDesc(stockId, OrderType.BUY);
-			if (orderAsk === undefined || orderAsk.amount <= 0) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
-
-			const orderBid = await OrderRepositoryRunner.readOrderByAsc(stockId, OrderType.SELL);
-			if (orderBid === undefined || orderBid.amount <= 0) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
-
-			if (orderBid.price < orderAsk.price) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
+			if (stock === undefined || orderAsk === undefined || orderBid === undefined || orderBid.price > orderAsk.price)
+				throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
 
 			const task = new BidAskTransaction(
 				StockRepositoryRunner,
@@ -49,7 +47,7 @@ export default class AuctioneerService {
 
 			const transactionLog: ITransactionLog = {
 				code,
-				price: orderBid.price,
+				price: orderAsk.createdAt < orderBid.createdAt ? orderBid.price : orderAsk.price,
 				amount: Math.min(orderBid.amount, orderAsk.amount),
 				createdAt: new Date().getTime(),
 			};

--- a/auctioneer/src/services/BidAskTransaction.ts
+++ b/auctioneer/src/services/BidAskTransaction.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import fetch from 'node-fetch';
 import { Stock, User, UserStock, Order, OrderStatus, Transaction, Chart } from '@models/index';
 import { StockRepository, UserRepository, UserStockRepository, OrderRepository, ChartRepository } from '@repositories/index';
@@ -98,7 +97,6 @@ export default class BidAskTransaction implements IBidAskTransaction {
 			},
 		});
 
-		/* eslint-disable no-param-reassign */
 		const updatedCharts = charts.map((chart: Chart) => {
 			if (chart.priceStart === 0) {
 				chart.priceStart = this.transactionLog.price;
@@ -112,8 +110,8 @@ export default class BidAskTransaction implements IBidAskTransaction {
 			return chart;
 		});
 
-		updatedCharts.forEach((chart: Chart) => {
-			this.ChartRepositoryRunner.update(chart.chartId, chart);
+		updatedCharts.forEach(async (chart: Chart) => {
+			await this.ChartRepositoryRunner.update(chart.chartId, chart);
 		});
 
 		fetch(`${process.env.API_SERVER_URL}/api/stock/conclusion`, {

--- a/front/src/pages/trade/bidAsk/BidAskInputs.tsx
+++ b/front/src/pages/trade/bidAsk/BidAskInputs.tsx
@@ -101,7 +101,6 @@ const BidAskInputs = ({
 						<input
 							className="bidask-info-text-input"
 							type="text"
-							dir="rtl"
 							value={formatNumber(bidAskPrice)}
 							onChange={handleOrderPrice}
 						/>
@@ -115,7 +114,6 @@ const BidAskInputs = ({
 					<input
 						className={orderAmountClass(isAmountError)}
 						type="text"
-						dir="rtl"
 						value={formatNumber(bidAskAmount)}
 						onChange={handleOrderAmount}
 					/>

--- a/front/src/pages/trade/bidAsk/bidask.scss
+++ b/front/src/pages/trade/bidAsk/bidask.scss
@@ -189,6 +189,7 @@
 	border: 1px solid $borderColor;
 	border-radius: 4px;
 	padding: 8px;
+	text-align: right;
 
 	&.error:not(:focus) {
 		border: 1px solid $red;


### PR DESCRIPTION
1. 거래 체결 결과를 mysql의 stock테이블에 반영

2. 주문체결 버그 수정 및 기능개선
체결 주문 후보 기준
->1순위 가격, 2순위 시간오름차순
체결 조건
->매도가<=매수가
체결가 결정 기준
->매도, 매수 주문 중 먼저 들어온 주문 기준
데이터베이스 조회 동작을 Promise.all으로 동시 실행하도록 개선.

3. 인풋태그 우측정렬 방법 변경