### PR TITLE
변수 타입 검증 클래스 추가

### DIFF
--- a/back/src/helper/Validator.ts
+++ b/back/src/helper/Validator.ts
@@ -1,0 +1,53 @@
+/* eslint-disable class-methods-use-this */
+
+export default class Validator {
+	private value: unknown;
+
+	init(value: unknown): this {
+		this.value = value;
+		return this;
+	}
+
+	isInteger(): this {
+		if (!Number.isSafeInteger(Number(this.value))) throw new Error('Validator Error: Not Integer Value');
+		return this;
+	}
+
+	isFloat(value: unknown): this {
+		if (Number(value) % 1 !== 0) throw new Error('Validator Error: Not Float Value');
+		return this;
+	}
+
+	isPositive(): this {
+		if (Number(this.value) <= 0) throw new Error('Validator Error: Not Positive Value');
+		return this;
+	}
+
+	isNegative(): this {
+		if (Number(this.value) >= 0) throw new Error('Validator Error: Not Negative Value');
+		return this;
+	}
+
+	isString(): this {
+		if (typeof this.value !== 'string') throw new Error('Validator Error: Not String Value');
+		return this;
+	}
+
+	isInObject(obj: Record<string, unknown>): this {
+		if (
+			!Object.values(obj)
+				.map((value: unknown) => String(value))
+				.includes(String(this.value))
+		)
+			throw new Error('Validator Error: Not Included Value');
+		return this;
+	}
+
+	toNumber(): number {
+		return Number(this.value);
+	}
+
+	toString(): string {
+		return String(this.value);
+	}
+}

--- a/back/src/helper/index.ts
+++ b/back/src/helper/index.ts
@@ -1,0 +1,5 @@
+// export * from './Validator';
+export { default as Validator } from './Validator';
+
+export * from './tools';
+// export { default as tools } from './tools';

--- a/back/src/repositories/StockRepository.ts
+++ b/back/src/repositories/StockRepository.ts
@@ -8,7 +8,7 @@ export default class StockRepository extends Repository<Stock> {
 		return result.identifiers.length > 0;
 	}
 
-	public async readAllStocks(): Promise<Stock[] | undefined> {
+	public async readAllStocks(): Promise<Stock[]> {
 		return this.find({
 			relations: ['charts'],
 		});

--- a/back/src/services/StockService.ts
+++ b/back/src/services/StockService.ts
@@ -20,32 +20,25 @@ export default class StockService {
 	}
 
 	public async getStockById(entityManager: EntityManager, id: number): Promise<Stock> {
-		if (!Number.isInteger(id)) throw new CommonError(CommonErrorMessage.INVALID_REQUEST);
-
 		const stockRepository: StockRepository = this.getStockRepository(entityManager);
 
-		const stockEntity = await stockRepository.readStockById(id);
-		if (!stockEntity) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
-		return stockEntity;
+		const stock = await stockRepository.readStockById(id);
+		if (!stock) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
+		return stock;
 	}
 
 	public async getStockByCode(entityManager: EntityManager, code: string): Promise<Stock> {
-		if (typeof code !== 'string') throw new CommonError(CommonErrorMessage.INVALID_REQUEST);
-
 		const stockRepository: StockRepository = this.getStockRepository(entityManager);
 
-		const stockEntity = await stockRepository.readStockByCode(code);
-		if (!stockEntity) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
-		return stockEntity;
+		const stock = await stockRepository.readStockByCode(code);
+		if (!stock) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
+		return stock;
 	}
 
 	public async getStocksCurrent(entityManager: EntityManager): Promise<Stock[]> {
 		const stockRepository: StockRepository = this.getStockRepository(entityManager);
-		const allStocks = await stockRepository.readAllStocks();
-		if (!allStocks) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
 
-		return allStocks.map((stock) => {
-			return { ...stock, charts: stock.charts.filter(({ type }) => type === 1440) };
-		});
+		const allStocks: Stock[] = await stockRepository.readAllStocks();
+		return allStocks.map((stock) => ({ ...stock, charts: stock.charts.filter(({ type }) => type === 1440) }));
 	}
 }

--- a/back/src/services/UserService.ts
+++ b/back/src/services/UserService.ts
@@ -26,55 +26,38 @@ export default class UserService {
 			email: string;
 			socialGithub: string;
 		},
-	): Promise<boolean> {
-		if (
-			typeof userData.username !== 'string' ||
-			typeof userData.email !== 'string' ||
-			typeof userData.socialGithub !== 'string'
-		)
-			throw new CommonError(CommonErrorMessage.INVALID_REQUEST);
-
+	): Promise<void> {
 		const userRepository: UserRepository = this.getUserRepository(entityManager);
 
-		const userEntity: User = userRepository.create({
-			...userData,
-			balance: 0,
-		});
-		return userRepository.createUser(userEntity);
+		userRepository.createUser(
+			userRepository.create({
+				...userData,
+				balance: 0,
+			}),
+		);
 	}
 
 	public async getUserById(entityManager: EntityManager, id: number): Promise<User> {
-		if (!Number.isInteger(id)) throw new CommonError(CommonErrorMessage.INVALID_REQUEST);
-
 		const userRepository: UserRepository = this.getUserRepository(entityManager);
 
-		const userEntity = await userRepository.readUserById(id);
-		if (!userEntity) throw new UserError(UserErrorMessage.NOT_EXIST_USER);
-		return userEntity;
+		const user = await userRepository.readUserById(id);
+		if (!user) throw new UserError(UserErrorMessage.NOT_EXIST_USER);
+		return user;
 	}
 
-	public async setBalance(entityManager: EntityManager, id: number, balance: number): Promise<boolean> {
-		if (!Number.isInteger(id) || !Number.isInteger(balance)) throw new CommonError(CommonErrorMessage.INVALID_REQUEST);
-
+	public async setBalance(entityManager: EntityManager, id: number, balance: number): Promise<void> {
 		const userRepository: UserRepository = this.getUserRepository(entityManager);
 
-		const userEntity: User = userRepository.create({
-			userId: id,
-			balance,
-		});
-
-		const result: boolean = await userRepository.updateUser(userEntity);
-		if (!result) throw new UserError(UserErrorMessage.NOT_EXIST_USER);
-		return result;
+		await userRepository.updateUser(
+			userRepository.create({
+				userId: id,
+				balance,
+			}),
+		);
 	}
 
-	public async deleteUser(entityManager: EntityManager, id: number): Promise<boolean> {
-		if (!Number.isInteger(id)) throw new CommonError(CommonErrorMessage.INVALID_REQUEST);
-
+	public async deleteUser(entityManager: EntityManager, id: number): Promise<void> {
 		const userRepository: UserRepository = this.getUserRepository(entityManager);
-
-		const result: boolean = await userRepository.deleteUser(id);
-		if (!result) throw new UserError(UserErrorMessage.NOT_EXIST_USER);
-		return result;
+		await userRepository.deleteUser(id);
 	}
 }


### PR DESCRIPTION
## 작업 목록
- 변수 검증 클래스 (Validator) 추가

## Validator
`req.body`의 경우 어떤 타입이 들어올지 알 수 없습니다.
따라서 올바른 타입의 값이 들어왔다고 확신할 수 없기 때문에 서비스에서 별도로 각 변수의 값을 확인해야 했습니다.
또한, 기본적으로 string이기 때문에 라우터 쪽에서도 number 타입 변수에는 타입 캐스팅을 해서 보내야 했습니다.

이 부분을 개선하기 위해 각 변수가 올바른 타입인지 검사하고 타입 캐스팅을 해주는 Validator 클래스를 추가하였습니다.
해당 클래스를 추가함으로써 OrderService나 기타 서비스에서 타입 체크를 더이상 하지 않아도 됩니다.

## 특이사항
현재 기준으로는 Validator가 던지는 throw를 아무도 받지 않기 때문에
transaction 함수 내에 try-catch를 추가해서 Validator의 throw를 받도록 수정하였습니다.
이렇게 나눠서 처리하지 않게 transaction 함수 자체를 수정하면 좋을 것 같은데, 일단은 현재 구조 그대로 임시조치 하였습니다.