### PR TITLE
주문 취소 및 정정 기능 추가

### DIFF
--- a/auctioneer/src/models/Order.ts
+++ b/auctioneer/src/models/Order.ts
@@ -1,7 +1,5 @@
 import 'reflect-metadata';
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
-import User from './User';
-import Stock from './Stock';
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
 export enum OrderType {
 	SELL = 1,
@@ -11,7 +9,6 @@ export enum OrderType {
 export enum OrderStatus {
 	PENDING = 'pending',
 	FINISHED = 'finished',
-	CANCELING = 'canceling',
 	CANCELED = 'canceled',
 }
 

--- a/auctioneer/src/models/Stock.ts
+++ b/auctioneer/src/models/Stock.ts
@@ -20,7 +20,4 @@ export default class Stock {
 
 	@Column({ name: 'previous_close' })
 	previousClose: number;
-
-	@Column()
-	unit: number;
 }

--- a/back/src/models/Order.ts
+++ b/back/src/models/Order.ts
@@ -1,7 +1,5 @@
 import 'reflect-metadata';
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
-import User from './User';
-import Stock from './Stock';
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
 export enum OrderType {
 	SELL = 1,
@@ -11,7 +9,6 @@ export enum OrderType {
 export enum OrderStatus {
 	PENDING = 'pending',
 	FINISHED = 'finished',
-	CANCELING = 'canceling',
 	CANCELED = 'canceled',
 }
 
@@ -20,12 +17,10 @@ export default class Order {
 	@PrimaryGeneratedColumn({ name: 'order_id' })
 	orderId: number;
 
-	@ManyToOne(() => User, (user: User) => user.userId)
-	@JoinColumn({ name: 'user_id' })
+	@Column({ name: 'user_id' })
 	userId: number;
 
-	@ManyToOne(() => Stock, (stock: Stock) => stock.stockId)
-	@JoinColumn({ name: 'stock_id' })
+	@Column({ name: 'stock_id' })
 	stockId: number;
 
 	@Column({ type: 'enum', enum: OrderType })

--- a/back/src/models/Stock.ts
+++ b/back/src/models/Stock.ts
@@ -23,9 +23,6 @@ export default class Stock {
 	@Column({ name: 'previous_close' })
 	previousClose: number;
 
-	@Column()
-	unit: number;
-
 	@OneToMany(() => Chart, (chart: Chart) => chart.stockId)
 	@JoinColumn({ name: 'charts' })
 	charts: Chart[];

--- a/back/src/repositories/OrderRepository.ts
+++ b/back/src/repositories/OrderRepository.ts
@@ -11,7 +11,6 @@ export default class OrderRepository extends Repository<Order> {
 	public async readOrderById(id: number): Promise<Order | undefined> {
 		return this.findOne(id, {
 			lock: { mode: 'pessimistic_write' },
-			relations: ['userId', 'stockId'],
 		});
 	}
 

--- a/back/src/services/errors/OrderError.ts
+++ b/back/src/services/errors/OrderError.ts
@@ -1,13 +1,10 @@
 import CommonError from './CommonError';
 
 export enum OrderErrorMessage {
-	INVALID_TYPE = 'Invalid Order Type',
-	INVALID_OPTION = 'Invalid Order Option',
-	INVALID_AMOUNT = 'Invalid Amount',
-	INVALID_PRICE = 'Invalid Price',
-	LACK_OF_BALANCE = 'Lack of Balance',
-	NOT_EXIST_ORDER = 'Not Exist Order',
-	NOT_PENDING_ORDER = 'Not Pending Order',
+	INVALID_ORDER = 'Invalid Order',
+	INVALID_DATA = 'Invalid Data',
+	NOT_ENOUGH_STOCK = 'Not Enough Stock',
+	NOT_ENOUGH_BALANCE = 'Not Enough Balance',
 }
 
 export default class OrderError extends CommonError {


### PR DESCRIPTION
## 작업 목록
- 주문 기능 리팩토링
  - 종목별 호가단위 검사 제거 (#72)
- 주문 취소 및 정정 기능 추가

## 주문 서비스
- #91

위 PR에서 변수에 대한 검증을 진행하므로 타입을 확인하는 로직들을 모두 제거하였습니다.
주문 함수를 리팩토링 하고, 리팩토링한 코드를 사용하여 취소 및 정정 함수를 구현하였습니다.

기능이 하는 역할을 요약하면 다음과 같습니다.
주문: 주문 생성, 매도자의 종목수량을 차감, 매수자의 예치금을 차감
취소: 주문 취소, 매도자의 종목수량을 반환, 매수자의 예치금을 반환
정정: 주문 수정, 매도자의 종목수량을 반환량과 차감량의 차이만큼 반영, 매수자의 예치금을 반환액과 차감액의 차액만큼 반영

코드 중복이 꽤 있는데, 가독성 좋게 통합하는 방법이 있다면 의견 남겨주시거나 병합 후 수정해주세요 ^^;;

## 특이사항
없음