### PR TITLE
마이 페이지, 현금 입출금 페이지, 사이드바 관심종목 토글 구현

### DIFF
--- a/back/src/api/user/user.ts
+++ b/back/src/api/user/user.ts
@@ -18,12 +18,12 @@ export default (): express.Router => {
 
 	router.get('/email', async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const { email } = req.body;
-			await UserService.getUserByEmail(email);
+			const { email } = req.query;
+			await UserService.getUserByEmail(String(email));
 			res.status(200).json({ result: false });
 		} catch (error) {
-			if (error instanceof UserError) res.status(200).json({ result: true });
-			if (error instanceof ParamError) res.status(200).json({ result: false });
+			if (error instanceof UserError) return res.status(200).json({ result: true });
+			if (error instanceof ParamError) return res.status(200).json({ result: false });
 			next(error);
 		}
 	});

--- a/back/src/services/UserService.ts
+++ b/back/src/services/UserService.ts
@@ -59,7 +59,7 @@ export default class UserService {
 	}
 
 	static async getUserByEmail(email: string): Promise<User> {
-		if (checkEmail(email)) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
+		if (!checkEmail(email)) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
 		const userRepository: UserRepository = getCustomRepository(UserRepository);
 		const user = await userRepository.findOne({ where: { email } });
 		if (user === undefined) throw new UserError(UserErrorMessage.NOT_EXIST_USER);

--- a/front/src/app.tsx
+++ b/front/src/app.tsx
@@ -40,7 +40,15 @@ const App: React.FC = () => {
 			},
 		}).then((res: Response) => {
 			if (res.ok) {
-				setUserState({ ...userState, isLoggedIn: true });
+				res.json().then((data) => {
+					setUserState({
+						...userState,
+						username: data.user.username,
+						email: data.user.email,
+						balance: data.user.balance,
+						isLoggedIn: true,
+					});
+				});
 			}
 		});
 	}, []);

--- a/front/src/app.tsx
+++ b/front/src/app.tsx
@@ -10,6 +10,8 @@ import HelloWorld from './HelloWorld';
 import SignIn from './pages/signIn/SignIn';
 import SignUp from './pages/signUp/SignUp';
 import Trade from './pages/trade/Trade';
+import My from './pages/my/My';
+import Balance from './pages/balance/Balance';
 import Socket from './Socket';
 
 export interface Ipage {
@@ -37,6 +39,8 @@ const App: React.FC = () => {
 						<Route exact path="/auth/signin/callback" component={SignIn} />
 						<Route exact path="/auth/signup" component={SignIn} />
 						<Route exact path="/auth/signup/callback" component={SignUp} />
+						<Route exact path="/my" component={My} />
+						<Route exact path="/balance" component={Balance} />
 						<Route path="/trade" component={Trade} />
 						<Route component={HelloWorld} />
 					</Switch>

--- a/front/src/app.tsx
+++ b/front/src/app.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import * as ReactDOM from 'react-dom';
-import { RecoilRoot } from 'recoil';
+import { RecoilRoot, useRecoilState } from 'recoil';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
+import User from '@recoil/user/index';
 import TopBar from '@common/topbar/TopBar';
 import Theme from './Theme';
 import './app.scss';
@@ -21,6 +22,7 @@ export interface Ipage {
 }
 
 const App: React.FC = () => {
+	const [userState, setUserState] = useRecoilState(User);
 	const pages: Ipage[] = [
 		{
 			id: 1,
@@ -28,6 +30,20 @@ const App: React.FC = () => {
 			title: 'Trade',
 		},
 	];
+
+	useEffect(() => {
+		fetch(`${process.env.SERVER_URL}/api/user`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		}).then((res: Response) => {
+			if (res.ok) {
+				setUserState({ ...userState, isLoggedIn: true });
+			}
+		});
+	}, []);
 
 	return (
 		<BrowserRouter>

--- a/front/src/common/topbar/menu/Menu.tsx
+++ b/front/src/common/topbar/menu/Menu.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
 import { Ipage } from '@src/app';
+import User from '@recoil/user/index';
 
 import style from './menu.module.scss';
 
@@ -9,6 +12,34 @@ interface Props {
 }
 
 const Menu = ({ pages }: Props) => {
+	const userState = useRecoilValue(User);
+
+	const getMenu = () => {
+		if (userState.isLoggedIn === true) {
+			return (
+				<div style={{ position: 'relative' }}>
+					<NavLink to="/my" className={(isActive) => (isActive ? `${style.active}` : '')}>
+						마이페이지
+					</NavLink>
+					<NavLink to="/balance" className={(isActive) => (isActive ? `${style.active}` : '')}>
+						입출금
+					</NavLink>
+				</div>
+			);
+		}
+
+		return (
+			<div style={{ position: 'relative' }}>
+				<NavLink to="/auth/signin" className={(isActive) => (isActive ? `${style.active}` : '')}>
+					로그인
+				</NavLink>
+				<NavLink to="/auth/signup" className={(isActive) => (isActive ? `${style.active}` : '')}>
+					회원가입
+				</NavLink>
+			</div>
+		);
+	};
+
 	return (
 		<nav className={style.container}>
 			<div>
@@ -18,20 +49,7 @@ const Menu = ({ pages }: Props) => {
 					</NavLink>
 				))}
 			</div>
-			<div style={{ position: 'relative' }}>
-				<NavLink to="/auth/signin" className={(isActive) => (isActive ? `${style.active}` : '')}>
-					로그인
-				</NavLink>
-				<NavLink to="/auth/signup" className={(isActive) => (isActive ? `${style.active}` : '')}>
-					회원가입
-				</NavLink>
-				<NavLink to="/my" className={(isActive) => (isActive ? `${style.active}` : '')}>
-					마이페이지
-				</NavLink>
-				<NavLink to="/balance" className={(isActive) => (isActive ? `${style.active}` : '')}>
-					입출금
-				</NavLink>
-			</div>
+			{getMenu()}
 		</nav>
 	);
 };

--- a/front/src/common/topbar/menu/Menu.tsx
+++ b/front/src/common/topbar/menu/Menu.tsx
@@ -25,6 +25,12 @@ const Menu = ({ pages }: Props) => {
 				<NavLink to="/auth/signup" className={(isActive) => (isActive ? `${style.active}` : '')}>
 					회원가입
 				</NavLink>
+				<NavLink to="/my" className={(isActive) => (isActive ? `${style.active}` : '')}>
+					마이페이지
+				</NavLink>
+				<NavLink to="/balance" className={(isActive) => (isActive ? `${style.active}` : '')}>
+					입출금
+				</NavLink>
 			</div>
 		</nav>
 	);

--- a/front/src/common/utils/toDateString.ts
+++ b/front/src/common/utils/toDateString.ts
@@ -1,0 +1,3 @@
+export default (timestamp: number) => {
+	return new Date(timestamp).toISOString().replace('T', ' ').replace(/\..*/, '');
+};

--- a/front/src/pages/balance/Balance.scss
+++ b/front/src/pages/balance/Balance.scss
@@ -1,0 +1,131 @@
+@import '@common/global.scss';
+@import '@common/mixins.scss';
+
+.balance {
+	display: flex;
+    flex-direction: column;
+    align-items: center;
+	justify-content: flex-start;
+
+    width: 100vw;
+    height: 100vh;
+    padding: 96px 32px 32px 32px;
+    box-sizing: border-box;
+}
+
+.balance__conatiner {
+	display: flex;
+    flex-direction: column;
+    align-items: center;
+	justify-content: flex-start;
+
+    width: 950px;
+    margin: 8px;
+    box-sizing: border-box;
+
+    background-color: white;
+	border-radius: $cardBorderRadius;
+	box-shadow: 2px 2px 4px $boxShadowColor;
+
+	@include darkModeCardStyle();
+}
+
+.balance__wrapper {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+
+    width: 100%;
+    padding: 8px;
+    box-sizing: border-box;
+}
+
+
+.balance__button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 100%;
+    height: 48px;
+    margin: 8px;
+    box-sizing: border-box;
+    border: none;
+    border-radius: 4px;
+
+    text-decoration: none;
+    cursor: pointer;
+
+    color: #fff;
+    background-color: $primary2;
+
+    &:hover {
+        background-color: $primary;
+        transition: background-color 0.5s;
+    }
+
+    &:disabled {
+        background-color: #bbb;
+        cursor: default;
+    }
+}
+
+.balance__box {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    width: 100%;
+    height: 64px;
+    padding: 16px;
+    margin: 8px;
+    box-sizing: border-box;
+
+    font-size: 13px;
+    line-height: 10px;
+
+    &.balance__box--fill {
+        background-color: #eee;
+
+        .dark-theme & {
+            background-color: $darkModeCardBorderColor;
+            color: $white;
+        }
+    }
+
+    &.balance__box--border {
+        border: 1px solid $borderColor;
+
+        .dark-theme & {
+            border: 1px solid $darkModeListHoverColor;
+            color: $white;
+        }
+    }
+}
+
+.balance__label {
+    font-size: 10pt;
+    font-weight: bold;
+    margin-left: 8px;
+}
+
+.balance__input {
+    width: 230px;
+    height: 32px;
+    padding: 8px;
+    margin: 8px;
+    box-sizing: border-box;
+    background-color: transparent;
+
+    border: 1px solid #ccc;
+
+    &:focus {
+        outline: none;
+        border: 1px solid $primary;
+    }
+
+    .dark-theme & {
+        color: $white;
+        border: 1px solid $darkModeListHoverColor;
+    }
+}

--- a/front/src/pages/balance/Balance.tsx
+++ b/front/src/pages/balance/Balance.tsx
@@ -16,12 +16,17 @@ enum TYPE {
 	입금 = 1,
 }
 
+enum STATUS {
+	진행중 = 0,
+	완료 = 1,
+}
+
 interface IHistory {
 	type: number;
 	bank: string;
 	bankAccount: string;
 	volume: number;
-	status: string;
+	status: number;
 	createdAt: number;
 }
 
@@ -39,7 +44,7 @@ const Balance = () => {
 				<div>{history.bank}</div>
 				<div>{history.bankAccount}</div>
 				<div className="my__item-number">{history.volume.toLocaleString()}</div>
-				<div className="my__item-number">{history.status}</div>
+				<div className="my__item-number">{STATUS[history.status]}</div>
 				<div className="my__item-number">{toDateString(history.createdAt)}</div>
 			</div>
 		);

--- a/front/src/pages/balance/Balance.tsx
+++ b/front/src/pages/balance/Balance.tsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect } from 'react';
+
+import Deposit from './Deposit';
+import Withdrawal from './Withdrawal';
+
+import './Balance.scss';
+
+enum TAB {
+	DEPOSIT = '입금',
+	WITHDRAWAL = '출금',
+}
+
+interface IBalance {
+	balanceType: string;
+
+	bank: string;
+	bankAccount: string;
+	volume: number;
+	status: string;
+}
+
+const Balance = () => {
+	const [tab, setTab] = useState<TAB>(TAB.DEPOSIT);
+	const [balances, setBalances] = useState<IBalance[]>([
+		{
+			balanceType: '입금',
+
+			bank: '○○은행',
+			bankAccount: '000-0000-0000-00',
+			volume: 1234567,
+			status: 'PENDING',
+		},
+	]);
+
+	const switchTab = (index: number) => setTab(Object.values(TAB)[index]);
+
+	const getCurrentTab = () => {
+		switch (tab) {
+			case TAB.DEPOSIT:
+				return <Deposit />;
+			case TAB.WITHDRAWAL:
+				return <Withdrawal />;
+			default:
+				return <Deposit />;
+		}
+	};
+
+	useEffect(() => {
+		fetch(`${process.env.SERVER_URL}/api/user/balances`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		}).then((res: Response) => {
+			console.log(res.ok);
+			// setBalances([]);
+		});
+	}, []);
+
+	const getBalance = (balance: IBalance) => {
+		return (
+			<div className="my__item">
+				<div>{balance.balanceType}</div>
+				<div>{balance.bank}</div>
+				<div>{balance.bankAccount}</div>
+				<div className="my__item-number">{balance.volume.toLocaleString()}</div>
+				<div className="my__item-number">{balance.status}</div>
+			</div>
+		);
+	};
+
+	return (
+		<div className="balance">
+			<div className="my__container">
+				<div className="my__tab">
+					{Object.keys(TAB).map((key, index) => (
+						<div
+							key={key}
+							className={`my__tab-item ${tab === TAB[key as keyof typeof TAB] ? 'selected' : ''}`}
+							role="button"
+							tabIndex={0}
+							onClick={() => switchTab(index)}
+							onKeyDown={() => switchTab(index)}
+						>
+							{Object.values(TAB)[index]}
+						</div>
+					))}
+				</div>
+				{getCurrentTab()}
+			</div>
+
+			<div className="my__container">
+				<div className="my__tab">
+					<div className="my__tab-item selected">입출금현황</div>
+				</div>
+				<div className="my__legend">
+					<div>종류</div>
+					<div>은행</div>
+					<div>계좌번호</div>
+					<div className="my__legend-number">금액 (원)</div>
+					<div className="my__legend-number">상태</div>
+				</div>
+				{balances.map((balance: IBalance) => getBalance(balance))}
+			</div>
+		</div>
+	);
+};
+
+export default Balance;

--- a/front/src/pages/balance/Balance.tsx
+++ b/front/src/pages/balance/Balance.tsx
@@ -60,7 +60,7 @@ const Balance = () => {
 
 	const getBalance = (balance: IBalance) => {
 		return (
-			<div className="my__item">
+			<div className="my__item" key={balance.bankAccount}>
 				<div>{balance.balanceType}</div>
 				<div>{balance.bank}</div>
 				<div>{balance.bankAccount}</div>

--- a/front/src/pages/balance/Deposit.tsx
+++ b/front/src/pages/balance/Deposit.tsx
@@ -2,7 +2,12 @@ import React, { ChangeEvent, useState } from 'react';
 import toast, { Toaster } from 'react-hot-toast';
 import formatNumber from '@src/common/utils/formatNumber';
 
-const Deposit = () => {
+interface DepositProps {
+	refresh: () => void;
+}
+
+const Deposit = (props: DepositProps) => {
+	const { refresh } = props;
 	const [bank, setBank] = useState<string>('');
 	const [account, setAccount] = useState<string>('');
 	const [balance, setBalance] = useState<string>('');
@@ -36,7 +41,7 @@ const Deposit = () => {
 			headers: {
 				'Content-Type': 'application/json;charset=utf-8',
 			},
-			body: JSON.stringify({ bank, account, balance }),
+			body: JSON.stringify({ bank, bankAccount: account, changeValue: Number(balance.replace(/,/g, '')) }),
 		})
 			.then((res: Response) => {
 				if (res.ok) {
@@ -50,6 +55,7 @@ const Deposit = () => {
 			})
 			.finally(() => {
 				setLoading(false);
+				refresh();
 			});
 	};
 

--- a/front/src/pages/balance/Deposit.tsx
+++ b/front/src/pages/balance/Deposit.tsx
@@ -1,0 +1,108 @@
+import React, { ChangeEvent, useState } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
+import formatNumber from '@src/common/utils/formatNumber';
+
+const Deposit = () => {
+	const [bank, setBank] = useState<string>('');
+	const [account, setAccount] = useState<string>('');
+	const [balance, setBalance] = useState<string>('');
+	const [loading, setLoading] = useState<boolean>(false);
+
+	const isValid = () => bank.length > 0 && account.length > 0 && balance.length > 0 && loading === false;
+
+	const changeBank = (ev: ChangeEvent<HTMLInputElement>) => {
+		setBank(ev.target.value);
+	};
+
+	const changeAccount = (ev: ChangeEvent<HTMLInputElement>) => {
+		const value = ev.target.value.replace(/[^0-9\\-]/g, '');
+		setAccount(value);
+	};
+
+	const changeBalance = (ev: ChangeEvent<HTMLInputElement>) => {
+		const value = Number(ev.target.value.replace(/,/g, ''));
+		if (Number.isInteger(value)) {
+			setBalance(formatNumber(value));
+		}
+	};
+
+	const submit = () => {
+		if (!isValid()) return;
+		setLoading(true);
+
+		fetch(`${process.env.SERVER_URL}/api/???`, {
+			method: 'POST',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json;charset=utf-8',
+			},
+			body: JSON.stringify({ bank, account, balance }),
+		})
+			.then((res: Response) => {
+				if (res.ok) {
+					toast.success('입금 신청이 완료되었습니다.');
+					setBank('');
+					setAccount('');
+					setBalance('');
+				} else {
+					toast.error('입금 신청에 실패했습니다. 잠시 후에 재시도 해 주세요.');
+				}
+			})
+			.finally(() => {
+				setLoading(false);
+			});
+	};
+
+	return (
+		<div className="balance__wrapper">
+			<Toaster />
+			<div className="balance__box balance__box--border">
+				<b>입금 계좌</b>
+				<br />
+				○○은행 000-0000-0000-00 (예금주: Boostock)
+			</div>
+			<label className="balance__label" htmlFor="bank">
+				은행명
+				<input
+					className="balance__input"
+					type="text"
+					id="bank"
+					name="bank"
+					maxLength={50}
+					value={bank}
+					onChange={changeBank}
+				/>
+			</label>
+			<label className="balance__label" htmlFor="account">
+				계좌번호
+				<input
+					className="balance__input"
+					type="text"
+					id="account"
+					name="account"
+					maxLength={50}
+					value={account}
+					onChange={changeAccount}
+				/>
+			</label>
+			<label className="balance__label" htmlFor="balance">
+				입금금액
+				<input
+					className="balance__input"
+					type="text"
+					id="balance"
+					name="balance"
+					maxLength={50}
+					value={balance}
+					onChange={changeBalance}
+				/>
+			</label>
+			<div className="balance__box balance__box--fill">
+				은행명, 계좌번호, 입금금액이 일치하는 입금 정보가 확인되면, 관리자 승인 후에 예치금이 입금됩니다.
+			</div>
+			<input type="button" className="balance__button" disabled={!isValid()} value="신청" onClick={submit} />
+		</div>
+	);
+};
+
+export default Deposit;

--- a/front/src/pages/balance/Deposit.tsx
+++ b/front/src/pages/balance/Deposit.tsx
@@ -30,7 +30,7 @@ const Deposit = () => {
 		if (!isValid()) return;
 		setLoading(true);
 
-		fetch(`${process.env.SERVER_URL}/api/???`, {
+		fetch(`${process.env.SERVER_URL}/api/user/balance/deposit`, {
 			method: 'POST',
 			credentials: 'include',
 			headers: {

--- a/front/src/pages/balance/Withdrawal.tsx
+++ b/front/src/pages/balance/Withdrawal.tsx
@@ -1,9 +1,14 @@
-import React, { ChangeEvent, useState, useEffect } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import toast, { Toaster } from 'react-hot-toast';
 import formatNumber from '@src/common/utils/formatNumber';
 
-const Withdrawal = () => {
-	const [myBalance, setMyBalance] = useState<number>(0);
+interface WithdrawalProps {
+	myBalance: number;
+	refresh: () => void;
+}
+
+const Withdrawal = (props: WithdrawalProps) => {
+	const { myBalance, refresh } = props;
 	const [bank, setBank] = useState<string>('');
 	const [account, setAccount] = useState<string>('');
 	const [balance, setBalance] = useState<string>('');
@@ -37,7 +42,7 @@ const Withdrawal = () => {
 			headers: {
 				'Content-Type': 'application/json;charset=utf-8',
 			},
-			body: JSON.stringify({ bank, account, balance }),
+			body: JSON.stringify({ bank, bankAccount: account, changeValue: -balance }),
 		})
 			.then((res: Response) => {
 				if (res.ok) {
@@ -51,23 +56,9 @@ const Withdrawal = () => {
 			})
 			.finally(() => {
 				setLoading(false);
+				refresh();
 			});
 	};
-
-	useEffect(() => {
-		fetch(`${process.env.SERVER_URL}/api/user/balance`, {
-			method: 'GET',
-			credentials: 'include',
-			headers: {
-				'Content-Type': 'application/json;charset=utf-8',
-			},
-		}).then(async (res: Response) => {
-			if (res.ok) {
-				const data = await res.json();
-				setMyBalance(data.balance);
-			}
-		});
-	}, []);
 
 	return (
 		<div className="balance__wrapper">
@@ -101,7 +92,7 @@ const Withdrawal = () => {
 				/>
 			</label>
 			<label className="balance__label" htmlFor="balance">
-				입금금액
+				출금금액
 				<input
 					className="balance__input"
 					type="text"

--- a/front/src/pages/balance/Withdrawal.tsx
+++ b/front/src/pages/balance/Withdrawal.tsx
@@ -31,7 +31,7 @@ const Withdrawal = () => {
 		if (!isValid()) return;
 		setLoading(true);
 
-		fetch(`${process.env.SERVER_URL}/api/???`, {
+		fetch(`${process.env.SERVER_URL}/api/user/balance/withdraw`, {
 			method: 'POST',
 			credentials: 'include',
 			headers: {

--- a/front/src/pages/balance/Withdrawal.tsx
+++ b/front/src/pages/balance/Withdrawal.tsx
@@ -1,0 +1,121 @@
+import React, { ChangeEvent, useState, useEffect } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
+import formatNumber from '@src/common/utils/formatNumber';
+
+const Withdrawal = () => {
+	const [myBalance, setMyBalance] = useState<number>(0);
+	const [bank, setBank] = useState<string>('');
+	const [account, setAccount] = useState<string>('');
+	const [balance, setBalance] = useState<string>('');
+	const [loading, setLoading] = useState<boolean>(false);
+
+	const isValid = () => bank.length > 0 && account.length > 0 && balance.length > 0 && loading === false;
+
+	const changeBank = (ev: ChangeEvent<HTMLInputElement>) => {
+		setBank(ev.target.value);
+	};
+
+	const changeAccount = (ev: ChangeEvent<HTMLInputElement>) => {
+		const value = ev.target.value.replace(/[^0-9\\-]/g, '');
+		setAccount(value);
+	};
+
+	const changeBalance = (ev: ChangeEvent<HTMLInputElement>) => {
+		const value = Number(ev.target.value.replace(/,/g, ''));
+		if (Number.isInteger(value)) {
+			setBalance(formatNumber(value));
+		}
+	};
+
+	const submit = () => {
+		if (!isValid()) return;
+		setLoading(true);
+
+		fetch(`${process.env.SERVER_URL}/api/???`, {
+			method: 'POST',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json;charset=utf-8',
+			},
+			body: JSON.stringify({ bank, account, balance }),
+		})
+			.then((res: Response) => {
+				if (res.ok) {
+					toast.success('출금 신청이 완료되었습니다.');
+					setBank('');
+					setAccount('');
+					setBalance('');
+				} else {
+					toast.error('출금 신청에 실패했습니다. 잠시 후에 재시도 해 주세요.');
+				}
+			})
+			.finally(() => {
+				setLoading(false);
+			});
+	};
+
+	useEffect(() => {
+		fetch(`${process.env.SERVER_URL}/api/user/balance`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json;charset=utf-8',
+			},
+		}).then(async (res: Response) => {
+			if (res.ok) {
+				const data = await res.json();
+				setMyBalance(data.balance);
+			}
+		});
+	}, []);
+
+	return (
+		<div className="balance__wrapper">
+			<Toaster />
+			<div className="balance__box balance__box--border">
+				<b>출금 가능 금액</b>
+				<br />₩ {myBalance.toLocaleString()}
+			</div>
+			<label className="balance__label" htmlFor="bank">
+				은행명
+				<input
+					className="balance__input"
+					type="text"
+					id="bank"
+					name="bank"
+					maxLength={50}
+					value={bank}
+					onChange={changeBank}
+				/>
+			</label>
+			<label className="balance__label" htmlFor="account">
+				계좌번호
+				<input
+					className="balance__input"
+					type="text"
+					id="account"
+					name="account"
+					maxLength={50}
+					value={account}
+					onChange={changeAccount}
+				/>
+			</label>
+			<label className="balance__label" htmlFor="balance">
+				입금금액
+				<input
+					className="balance__input"
+					type="text"
+					id="balance"
+					name="balance"
+					maxLength={50}
+					value={balance}
+					onChange={changeBalance}
+				/>
+			</label>
+			<div className="balance__box balance__box--fill">관리자 승인 후에 입력한 계좌 정보로 예치금이 출금됩니다.</div>
+			<input type="button" className="balance__button" disabled={!isValid()} value="신청" onClick={submit} />
+		</div>
+	);
+};
+
+export default Withdrawal;

--- a/front/src/pages/my/Holds.scss
+++ b/front/src/pages/my/Holds.scss
@@ -1,0 +1,8 @@
+@import '@common/mixins.scss';
+
+.my-holds {
+    width: 100%;
+    height: 60vh;
+
+    @include darkModeCardStyle();
+}

--- a/front/src/pages/my/Holds.tsx
+++ b/front/src/pages/my/Holds.tsx
@@ -1,53 +1,21 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import caretIcon from '@src/common/utils/caretIcon';
-
+import { IHold } from './IHold';
 import './Holds.scss';
 
-interface IHold {
-	stockCode: string;
-	stockName: string;
-
-	holdAmount: number;
-	averageAskPrice: number;
-	totalAskPrice: number;
-
-	totalValuationPrice: number;
-	totalValuationProfit: number;
+interface HoldsProps {
+	holds: IHold[];
 }
 
-const Holds = () => {
-	const [holds, setHolds] = useState<IHold[]>([
-		{
-			stockCode: 'HNX',
-			stockName: '호눅스',
-
-			holdAmount: 1234567,
-			averageAskPrice: 1234567,
-			totalAskPrice: 1234567,
-
-			totalValuationPrice: 1234567,
-			totalValuationProfit: 1234.567,
-		},
-	]);
-
-	useEffect(() => {
-		fetch(`${process.env.SERVER_URL}/api/user/hold`, {
-			method: 'GET',
-			credentials: 'include',
-			headers: {
-				'Content-Type': 'application/json; charset=utf-8',
-			},
-		}).then((res: Response) => {
-			console.log(res.ok);
-			// setHolds([]);
-		});
-	}, []);
+const Holds = (props: HoldsProps) => {
+	const { holds } = props;
 
 	const getHold = (hold: IHold) => {
 		let status = ' ';
 		if (hold.totalValuationProfit > 0) status = ' my__item--up';
 		else if (hold.totalValuationProfit < 0) status = ' my__item--down';
 
+		const profitRate = (hold.totalValuationPrice / hold.totalAskPrice) * 100;
 		return (
 			<div className="my__item" key={hold.stockCode}>
 				<div>
@@ -60,8 +28,7 @@ const Holds = () => {
 				<div className="my__item-number">{hold.totalAskPrice.toLocaleString()}</div>
 				<div className={`my__item-number${status}`}>{hold.totalValuationPrice.toLocaleString()}</div>
 				<div className={`my__item-number${status}`}>
-					{caretIcon(hold.totalValuationProfit)}{' '}
-					{hold.totalValuationProfit.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+					{caretIcon(profitRate)} {profitRate.toLocaleString(undefined, { maximumFractionDigits: 2 })}
 				</div>
 			</div>
 		);

--- a/front/src/pages/my/Holds.tsx
+++ b/front/src/pages/my/Holds.tsx
@@ -71,7 +71,7 @@ const Holds = () => {
 		<div className="my-holds">
 			<div className="my__legend">
 				<div>종목명</div>
-				<div className="my__legend-number">보유수량 (개)</div>
+				<div className="my__legend-number">보유수량 (주)</div>
 				<div className="my__legend-number">평균매수가 (원)</div>
 				<div className="my__legend-number">매수금액 (원)</div>
 				<div className="my__legend-number">평가금액 (원)</div>

--- a/front/src/pages/my/Holds.tsx
+++ b/front/src/pages/my/Holds.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import caretIcon from '@src/common/utils/caretIcon';
+
+import './Holds.scss';
+
+interface IHold {
+	stockCode: string;
+	stockName: string;
+
+	holdAmount: number;
+	averageAskPrice: number;
+	totalAskPrice: number;
+
+	totalValuationPrice: number;
+	totalValuationProfit: number;
+}
+
+const Holds = () => {
+	const [holds, setHolds] = useState<IHold[]>([
+		{
+			stockCode: 'HNX',
+			stockName: '호눅스',
+
+			holdAmount: 1234567,
+			averageAskPrice: 1234567,
+			totalAskPrice: 1234567,
+
+			totalValuationPrice: 1234567,
+			totalValuationProfit: 1234.567,
+		},
+	]);
+
+	useEffect(() => {
+		fetch(`${process.env.SERVER_URL}/api/user/hold`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		}).then((res: Response) => {
+			console.log(res.ok);
+			// setHolds([]);
+		});
+	}, []);
+
+	const getHold = (hold: IHold) => {
+		let status = ' ';
+		if (hold.totalValuationProfit > 0) status = ' my__item--up';
+		else if (hold.totalValuationProfit < 0) status = ' my__item--down';
+
+		return (
+			<div className="my__item" key={hold.stockCode}>
+				<div>
+					<span className="my__item-unit">{hold.stockCode}</span>
+					<br />
+					<span className="my__item-title">{hold.stockName}</span>
+				</div>
+				<div className="my__item-number">{hold.holdAmount.toLocaleString()}</div>
+				<div className="my__item-number">{hold.averageAskPrice.toLocaleString()}</div>
+				<div className="my__item-number">{hold.totalAskPrice.toLocaleString()}</div>
+				<div className={`my__item-number${status}`}>{hold.totalValuationPrice.toLocaleString()}</div>
+				<div className={`my__item-number${status}`}>
+					{caretIcon(hold.totalValuationProfit)}{' '}
+					{hold.totalValuationProfit.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+				</div>
+			</div>
+		);
+	};
+
+	return (
+		<div className="my-holds">
+			<div className="my__legend">
+				<div>종목명</div>
+				<div className="my__legend-number">보유수량 (개)</div>
+				<div className="my__legend-number">평균매수가 (원)</div>
+				<div className="my__legend-number">매수금액 (원)</div>
+				<div className="my__legend-number">평가금액 (원)</div>
+				<div className="my__legend-number">평가손익 (%)</div>
+			</div>
+			{holds.map((hold: IHold) => getHold(hold))}
+		</div>
+	);
+};
+
+export default Holds;

--- a/front/src/pages/my/IHold.ts
+++ b/front/src/pages/my/IHold.ts
@@ -1,0 +1,11 @@
+export interface IHold {
+	stockCode: string;
+	stockName: string;
+
+	holdAmount: number;
+	averageAskPrice: number;
+	totalAskPrice: number;
+
+	totalValuationPrice: number;
+	totalValuationProfit: number;
+}

--- a/front/src/pages/my/Info.scss
+++ b/front/src/pages/my/Info.scss
@@ -1,0 +1,72 @@
+@import '@common/global.scss';
+@import '@common/mixins.scss';
+
+.my-info {
+    width: 100%;
+    height: 150px;
+
+    @include darkModeCardStyle();
+}
+
+.my-info__top {
+    height: 60%;
+    padding: 16px;
+    box-sizing: border-box;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    border-bottom: 1px solid $borderColor;
+
+    .dark-theme & {
+		border-bottom: 1px solid $darkModeBorderColor;
+	}
+}
+
+.my-info__bottom {
+    height: 40%;
+    padding: 16px;
+    box-sizing: border-box;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.my-info__group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    width: 100%;
+
+    .my-info__title--top {
+        font-size: 14px;
+        font-weight: bold;
+        line-height: 24px;
+    }
+
+    .my-info__title--bottom {
+        font-size: 12px;
+        font-weight: bold;
+        line-height: 16px;
+    }
+
+    .my-info__data--top {
+        font-size: 24px;
+    }
+
+    .my-info__data--bottom {
+        font-size: 16px;
+    }
+
+    .my-info__data--up {
+        color: $red;
+    }
+
+    .my-info__data--down {
+        color: $blue;
+    }
+}

--- a/front/src/pages/my/Info.tsx
+++ b/front/src/pages/my/Info.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+
+import './Info.scss';
+
+interface IInfo {
+	balance: number;
+	totalAskPrice: number;
+	totalValuationPrice: number;
+	totalValuationProfit: number;
+
+	totalAssets: number;
+	totalRate: number;
+}
+
+const Holds = () => {
+	const [info, setInfo] = useState<IInfo | null>(null);
+
+	useEffect(() => {
+		fetch(`${process.env.SERVER_URL}/api/user/info`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		}).then((res: Response) => {
+			console.log(res.ok);
+			setInfo(null);
+		});
+	}, []);
+
+	return (
+		<div className="my-info">
+			<div className="my-info__top">
+				<div className="my-info__group">
+					<div className="my-info__title--top">총자산</div>
+					<div className="my-info__data--top">₩ {info?.totalAssets.toLocaleString() || '-'}</div>
+				</div>
+				<div className="my-info__group">
+					<div className="my-info__title--top my-info__data--up">수익률</div>
+					<div className="my-info__data--top my-info__data--up">
+						{info?.totalAssets.toLocaleString(undefined, { maximumFractionDigits: 2 }) || '-'} %
+					</div>
+				</div>
+			</div>
+			<div className="my-info__bottom">
+				<div className="my-info__group">
+					<div className="my-info__title--bottom">현금자산</div>
+					<div className="my-info__data--bottom">₩ {info?.balance || '-'}</div>
+				</div>
+				<div className="my-info__group">
+					<div className="my-info__title--bottom">총매수금액</div>
+					<div className="my-info__data--bottom">₩ {info?.totalAskPrice || '-'}</div>
+				</div>
+				<div className="my-info__group">
+					<div className="my-info__title--bottom">총평가금액</div>
+					<div className="my-info__data--bottom">₩ {info?.totalValuationPrice || '-'}</div>
+				</div>
+				<div className="my-info__group">
+					<div className="my-info__title--bottom ">총평가손익</div>
+					<div className="my-info__data--bottom my-info__data--up">₩ {info?.totalValuationProfit || '-'}</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default Holds;

--- a/front/src/pages/my/Info.tsx
+++ b/front/src/pages/my/Info.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-
+import { IHold } from './IHold';
 import './Info.scss';
 
 interface IInfo {
@@ -11,22 +11,37 @@ interface IInfo {
 	totalAssets: number;
 	totalRate: number;
 }
+interface InfoProps {
+	holds: IHold[];
+}
 
-const Holds = () => {
+const Info = (props: InfoProps) => {
+	const { holds } = props;
 	const [info, setInfo] = useState<IInfo | null>(null);
 
 	useEffect(() => {
-		fetch(`${process.env.SERVER_URL}/api/user/info`, {
+		fetch(`${process.env.SERVER_URL}/api/user/balance`, {
 			method: 'GET',
 			credentials: 'include',
 			headers: {
-				'Content-Type': 'application/json; charset=utf-8',
+				'Content-Type': 'application/json;charset=utf-8',
 			},
 		}).then((res: Response) => {
-			console.log(res.ok);
-			setInfo(null);
+			if (res.ok) {
+				res.json().then((data) => {
+					const { balance } = data;
+					const totalAskPrice = holds.reduce((prev, hold) => prev + hold.totalAskPrice, 0);
+					const totalValuationPrice = holds.reduce((prev, hold) => prev + hold.totalValuationPrice, 0);
+					const totalValuationProfit = totalValuationPrice - totalAskPrice;
+
+					const totalAssets = balance + totalValuationPrice;
+					const totalRate = (totalValuationPrice / totalAskPrice) * 100 || 0;
+
+					setInfo({ balance, totalAskPrice, totalValuationPrice, totalValuationProfit, totalAssets, totalRate });
+				});
+			}
 		});
-	}, []);
+	}, [holds]);
 
 	return (
 		<div className="my-info">
@@ -38,7 +53,7 @@ const Holds = () => {
 				<div className="my-info__group">
 					<div className="my-info__title--top my-info__data--up">수익률</div>
 					<div className="my-info__data--top my-info__data--up">
-						{info?.totalAssets.toLocaleString(undefined, { maximumFractionDigits: 2 }) || '-'} %
+						{info?.totalRate.toLocaleString(undefined, { maximumFractionDigits: 2 }) || '-'} %
 					</div>
 				</div>
 			</div>
@@ -64,4 +79,4 @@ const Holds = () => {
 	);
 };
 
-export default Holds;
+export default Info;

--- a/front/src/pages/my/My.scss
+++ b/front/src/pages/my/My.scss
@@ -1,0 +1,144 @@
+@import '@common/global.scss';
+@import '@common/mixins.scss';
+
+.my {
+	display: flex;
+    flex-direction: column;
+    align-items: center;
+	justify-content: flex-start;
+
+    width: 100vw;
+    height: 100vh;
+    padding: 96px 32px 32px 32px;
+    box-sizing: border-box;
+}
+
+.my__container {
+	display: flex;
+    flex-direction: column;
+    align-items: center;
+	justify-content: flex-start;
+
+    width: 950px;
+    margin: 8px;
+    box-sizing: border-box;
+
+    background-color: white;
+	border-radius: $cardBorderRadius;
+	box-shadow: 2px 2px 4px $boxShadowColor;
+
+	@include darkModeCardStyle();
+}
+
+.my__tab {
+	width: 100%;
+
+	display: flex;
+	align-items: center;
+
+	border-bottom: 1px solid $borderColor;
+
+	.dark-theme & {
+		border-bottom: 1px solid $darkModeBorderColor;
+	}
+
+	.my__tab-item {
+		width: 150px;
+		height: 48px;
+        padding: 0px 32px 0px 32px;
+        box-sizing: border-box;
+
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		cursor: pointer;
+
+		&:hover {
+			font-weight: bold;
+		}
+
+		&.selected {
+			font-weight: bold;
+			border-bottom: 4px solid $primary;
+		}
+
+		.dark-theme &.selected {
+			border-bottom: 4px solid $primary2;
+		}
+	}
+}
+
+.my__legend {
+	width: 100%;
+	height: 32px;
+	padding: 0px 10px;
+	box-sizing: border-box;
+	font-size: 12px;
+	font-weight: 700;
+
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	color: $blueGray;
+	border-bottom: 1px solid $borderColor;
+	background-color: $white2;
+
+	.dark-theme & {
+		color: $gray;
+		background-color: $darkGray;
+		border-bottom: 1px solid $darkModeBorderColor;
+	}
+
+    & > * {
+        width: 100%;
+    }
+
+    & > .my__legend-number {
+        text-align: right;
+    }
+}
+
+.my__item {
+	width: 100%;
+	height: 48px;
+	padding: 0px 10px;
+	box-sizing: border-box;
+	border-bottom: 1px solid $borderColor;
+
+    display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	font-size: 12px;
+
+	.dark-theme & {
+		border-bottom: 1px solid $darkModeBorderColor;
+	}
+
+    & > * {
+        width: 100%;
+    }
+
+	.my__item-title {
+		font-weight: bold;
+	}
+
+    .my__item-number {
+        text-align: right;
+    }
+
+	.my__item-unit {
+		color: #bbb;
+		font-size: 11px;
+	}
+
+	.my__item--up {
+        color: $red;
+    }
+
+	.my__item--down {
+        color: $blue;
+    }
+}

--- a/front/src/pages/my/My.tsx
+++ b/front/src/pages/my/My.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+
+import Info from './Info';
+import Holds from './Holds';
+import Transactions from './Transactions';
+import Orders from './Orders';
+
+import './My.scss';
+
+enum TAB {
+	HOLDS = '보유종목',
+	TRANSACTIONS = '체결내역',
+	ORDERS = '주문내역',
+}
+
+const My = () => {
+	const [tab, setTab] = useState<TAB>(TAB.HOLDS);
+
+	const switchTab = (index: number) => setTab(Object.values(TAB)[index]);
+
+	const getCurrentTab = () => {
+		switch (tab) {
+			case TAB.HOLDS:
+				return <Holds key={tab} />;
+			case TAB.TRANSACTIONS:
+				return <Transactions key={tab} />;
+			case TAB.ORDERS:
+				return <Orders key={tab} />;
+			default:
+				return <Holds key={tab} />;
+		}
+	};
+
+	return (
+		<div className="my">
+			<div className="my__container">
+				<Info />
+			</div>
+			<div className="my__container">
+				<div className="my__tab">
+					{Object.keys(TAB).map((key, index) => (
+						<div
+							key={key}
+							className={`my__tab-item ${tab === TAB[key as keyof typeof TAB] ? 'selected' : ''}`}
+							role="button"
+							tabIndex={0}
+							onClick={() => switchTab(index)}
+							onKeyDown={() => switchTab(index)}
+						>
+							{Object.values(TAB)[index]}
+						</div>
+					))}
+				</div>
+				{getCurrentTab()}
+			</div>
+		</div>
+	);
+};
+
+export default My;

--- a/front/src/pages/my/Orders.scss
+++ b/front/src/pages/my/Orders.scss
@@ -1,0 +1,8 @@
+@import '@common/mixins.scss';
+
+.my-orders {
+    width: 100%;
+    height: 60vh;
+
+    @include darkModeCardStyle();
+}

--- a/front/src/pages/my/Orders.tsx
+++ b/front/src/pages/my/Orders.tsx
@@ -12,7 +12,6 @@ interface IOrder {
 
 	price: number;
 	orderAmount: number;
-	remainAmount: number;
 
 	status: string;
 }
@@ -28,7 +27,6 @@ const Orders = () => {
 
 			price: 1234567,
 			orderAmount: 1234567,
-			remainAmount: 1234567,
 
 			status: 'PENDING',
 		},
@@ -63,7 +61,6 @@ const Orders = () => {
 				</div>
 				<div className="my__item-number">{order.price.toLocaleString()}</div>
 				<div className="my__item-number">{order.orderAmount.toLocaleString()}</div>
-				<div className="my__item-number">{order.remainAmount.toLocaleString()}</div>
 				<div className="my__item-number">{order.status}</div>
 			</div>
 		);
@@ -76,8 +73,7 @@ const Orders = () => {
 				<div>주문종류</div>
 				<div>종목명</div>
 				<div className="my__legend-number">주문가격 (원)</div>
-				<div className="my__legend-number">주문수량 (개)</div>
-				<div className="my__legend-number">남은수량 (개)</div>
+				<div className="my__legend-number">주문수량 (주)</div>
 				<div className="my__legend-number">상태</div>
 			</div>
 			{orders.map((order: IOrder) => getOrder(order))}

--- a/front/src/pages/my/Orders.tsx
+++ b/front/src/pages/my/Orders.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from 'react';
+import toDateString from '@src/common/utils/toDateString';
+
+import './Orders.scss';
+
+interface IOrder {
+	orderTime: number;
+	orderType: string;
+
+	stockCode: string;
+	stockName: string;
+
+	price: number;
+	orderAmount: number;
+	remainAmount: number;
+
+	status: string;
+}
+
+const Orders = () => {
+	const [orders, setOrders] = useState<IOrder[]>([
+		{
+			orderTime: 1637043806237,
+			orderType: '매도',
+
+			stockCode: 'HNX',
+			stockName: '호눅스',
+
+			price: 1234567,
+			orderAmount: 1234567,
+			remainAmount: 1234567,
+
+			status: 'PENDING',
+		},
+	]);
+
+	useEffect(() => {
+		fetch(`${process.env.SERVER_URL}/api/user/orders`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		}).then((res: Response) => {
+			console.log(res.ok);
+			// setOrders([]);
+		});
+	}, []);
+
+	const getOrder = (order: IOrder) => {
+		let status = ' ';
+		if (order.orderType === '매수') status = ' my__item--up';
+		else if (order.orderType === '매도') status = ' my__item--down';
+
+		return (
+			<div className="my__item" key={order.orderTime}>
+				<div>{toDateString(order.orderTime)}</div>
+				<div className={status}>{order.orderType}</div>
+				<div>
+					<span className="my__item-unit">{order.stockCode}</span>
+					<br />
+					<span className="my__item-title">{order.stockName}</span>
+				</div>
+				<div className="my__item-number">{order.price.toLocaleString()}</div>
+				<div className="my__item-number">{order.orderAmount.toLocaleString()}</div>
+				<div className="my__item-number">{order.remainAmount.toLocaleString()}</div>
+				<div className="my__item-number">{order.status}</div>
+			</div>
+		);
+	};
+
+	return (
+		<div className="my-orders">
+			<div className="my__legend">
+				<div>주문시간</div>
+				<div>주문종류</div>
+				<div>종목명</div>
+				<div className="my__legend-number">주문가격 (원)</div>
+				<div className="my__legend-number">주문수량 (개)</div>
+				<div className="my__legend-number">남은수량 (개)</div>
+				<div className="my__legend-number">상태</div>
+			</div>
+			{orders.map((order: IOrder) => getOrder(order))}
+		</div>
+	);
+};
+
+export default Orders;

--- a/front/src/pages/my/Transactions.scss
+++ b/front/src/pages/my/Transactions.scss
@@ -1,0 +1,8 @@
+@import '@common/mixins.scss';
+
+.my-transactions {
+    width: 100%;
+    height: 60vh;
+
+    @include darkModeCardStyle();
+}

--- a/front/src/pages/my/Transactions.tsx
+++ b/front/src/pages/my/Transactions.tsx
@@ -1,0 +1,81 @@
+import React, { useState, useEffect } from 'react';
+import toDateString from '@src/common/utils/toDateString';
+
+import './Transactions.scss';
+
+interface ITransaction {
+	transactionTime: number;
+	orderType: string;
+
+	stockCode: string;
+	stockName: string;
+
+	price: number;
+	amount: number;
+	volume: number;
+}
+
+const Transactions = () => {
+	const [transactions, setTransactions] = useState<ITransaction[]>([
+		{
+			transactionTime: 1637043806237,
+			orderType: '매도',
+			stockCode: 'HNX',
+			stockName: '호눅스',
+			price: 1234567,
+			amount: 1234567,
+			volume: 1234567,
+		},
+	]);
+
+	useEffect(() => {
+		fetch(`${process.env.SERVER_URL}/api/user/transactions`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		}).then((res: Response) => {
+			console.log(res.ok);
+			// setTransactions([]);
+		});
+	}, []);
+
+	const getTransaction = (transaction: ITransaction) => {
+		let status = ' ';
+		if (transaction.orderType === '매수') status = ' my__item--up';
+		else if (transaction.orderType === '매도') status = ' my__item--down';
+
+		return (
+			<div className="my__item" key={transaction.transactionTime}>
+				<div>{toDateString(transaction.transactionTime)}</div>
+				<div className={status}>{transaction.orderType}</div>
+				<div>
+					<span className="my__item-unit">{transaction.stockCode}</span>
+					<br />
+					<span className="my__item-title">{transaction.stockName}</span>
+				</div>
+				<div className="my__item-number">{transaction.amount.toLocaleString()}</div>
+				<div className="my__item-number">{transaction.price.toLocaleString()}</div>
+				<div className="my__item-number">{transaction.volume.toLocaleString()}</div>
+			</div>
+		);
+	};
+
+	return (
+		<div className="my-transactions">
+			<div className="my__legend">
+				<div>체결시간</div>
+				<div>주문종류</div>
+				<div>종목명</div>
+				<div className="my__legend-number">거래수량 (개)</div>
+				<div className="my__legend-number">거래단가 (원)</div>
+				<div className="my__legend-number">거래금액 (원)</div>
+			</div>
+
+			{transactions.map((transaction: ITransaction) => getTransaction(transaction))}
+		</div>
+	);
+};
+
+export default Transactions;

--- a/front/src/pages/my/Transactions.tsx
+++ b/front/src/pages/my/Transactions.tsx
@@ -68,7 +68,7 @@ const Transactions = () => {
 				<div>체결시간</div>
 				<div>주문종류</div>
 				<div>종목명</div>
-				<div className="my__legend-number">거래수량 (개)</div>
+				<div className="my__legend-number">거래수량 (주)</div>
 				<div className="my__legend-number">거래단가 (원)</div>
 				<div className="my__legend-number">거래금액 (원)</div>
 			</div>

--- a/front/src/pages/signIn/SignIn.tsx
+++ b/front/src/pages/signIn/SignIn.tsx
@@ -1,11 +1,16 @@
 import React, { useState } from 'react';
+import { useRecoilState } from 'recoil';
+import toast, { Toaster } from 'react-hot-toast';
 import { Link, Redirect, useLocation } from 'react-router-dom';
+
+import User from '@recoil/user/index';
 
 import './SignIn.scss';
 
 const SignIn = () => {
 	const { pathname, search } = useLocation();
 	const query = new URLSearchParams(search);
+	const [userState, setUserState] = useRecoilState(User);
 	const [result, setResult] = useState<boolean>(false);
 
 	const isSignUp = pathname === '/auth/signup';
@@ -23,7 +28,12 @@ const SignIn = () => {
 			},
 			body: JSON.stringify({ code: query.get('code') }),
 		}).then((res: Response) => {
-			setResult(res.ok);
+			if (res.ok) {
+				setUserState({ ...userState, isLoggedIn: true });
+				setResult(true);
+			} else {
+				toast.error('로그인에 실패했습니다. 잠시 후 재시도 해주세요.');
+			}
 		});
 	}
 
@@ -31,6 +41,7 @@ const SignIn = () => {
 
 	return (
 		<div className="signin">
+			<Toaster />
 			<h1>{TEXT}</h1>
 			<a
 				className="signin-button github-type"

--- a/front/src/pages/signUp/SignUp.scss
+++ b/front/src/pages/signUp/SignUp.scss
@@ -10,6 +10,13 @@
     height: 100vh;
 }
 
+.signup-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+	justify-content: center;
+}
+
 .signup-box {
     width: 800px;
     height: 300px;
@@ -31,15 +38,19 @@
 .signup-horizontal-group {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
 
     width: 800px;
-    height: 100px;
 }
 
 .signup-label {
     font-size: 10pt;
     font-weight: bold;
+
+    span {
+        display: inline-block;
+        width: 50px;
+    }
 }
 
 .signup-input {
@@ -82,5 +93,11 @@
     &:disabled {
         background-color: #bbb;
         cursor: default;
+    }
+
+    &.signup-submit-validate {
+        width: 200px;
+        padding: 8px;
+        box-sizing: border-box;
     }
 }

--- a/front/src/pages/signUp/SignUp.tsx
+++ b/front/src/pages/signUp/SignUp.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, useState } from 'react';
+import toast, { Toaster } from 'react-hot-toast';
 import { Redirect, useLocation } from 'react-router-dom';
 
 import './SignUp.scss';
@@ -9,15 +10,39 @@ const SignUp = () => {
 
 	const [username, setUsername] = useState<string>('');
 	const [email, setEmail] = useState<string>('');
+	const [isEmailValidate, setEmailValidate] = useState<boolean>(false);
 	const [term, setTerm] = useState<boolean>(false);
 	const [result, setResult] = useState<boolean>(false);
+
+	const emailValidator = new RegExp('\\S+@\\S+\\.\\S+');
 
 	const changeName = (event: ChangeEvent<HTMLInputElement>) => setUsername(event.target.value);
 	const changeEmail = (event: ChangeEvent<HTMLInputElement>) => setEmail(event.target.value);
 	const changeTerm = () => setTerm((prev) => !prev);
 
+	const isValid = () => username.length > 0 && emailValidator.test(email) && isEmailValidate && term;
+
+	const checkEamil = () => {
+		fetch(`${process.env.SERVER_URL}/api/user/email?email=${email}`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json;charset=utf-8',
+			},
+		}).then((res: Response) => {
+			if (res.ok) {
+				res.json().then((data) => {
+					setEmailValidate(data.result);
+					if (data.result === true) toast.success('사용할 수 있는 이메일입니다.');
+					else toast.error('이 이메일은 사용할 수 없습니다.');
+				});
+			} else {
+				toast.error('중복확인에 실패했습니다.');
+			}
+		});
+	};
+
 	const submit = () => {
-		const emailValidator = new RegExp('\\S+@\\S+\\.\\S+');
 		if (!emailValidator.test(email)) return;
 
 		fetch(`${process.env.SERVER_URL}/api/auth/github/signup`, {
@@ -36,38 +61,41 @@ const SignUp = () => {
 
 	return (
 		<form className="signup" action="#">
-			<h1>회원가입</h1>
-			<div className="signup-box">
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam tincidunt elementum facilisis. Duis ac ligula
-				feugiat, tempor tellus sit amet, egestas turpis. Maecenas purus ipsum, porttitor at sodales quis, sollicitudin et
-				ipsum. Donec eleifend et nisi non semper. Nulla id fermentum dui. Vivamus hendrerit erat luctus, tincidunt nisi
-				in, finibus lacus. Aliquam sed arcu non lacus dapibus finibus sit amet sed turpis. Sed pharetra ante eget
-				sollicitudin rhoncus. Integer rhoncus ligula nec congue vulputate. Aenean sed justo ac est scelerisque malesuada.
-				Curabitur laoreet urna sit amet sem porta, et finibus risus convallis. Aenean vitae tortor cursus, vestibulum
-				purus bibendum, efficitur nibh. Suspendisse potenti. Ut nulla elit, posuere id fermentum vitae, efficitur a nunc.
-				Praesent sed mauris pharetra, suscipit magna et, ultricies ligula. Phasellus lacinia ut metus id cursus. Ut
-				tincidunt luctus nisl ut auctor. Pellentesque ullamcorper orci nibh, eu gravida felis tempor a. Integer vel est a
-				mauris pharetra ultrices. Sed consequat vehicula ipsum quis viverra. Phasellus vitae nisl lorem. Praesent
-				dignissim blandit nunc nec consectetur. Nunc vitae metus sit amet lectus vestibulum fermentum. Sed tristique ac
-				nisl a convallis. In molestie, ligula non pellentesque lobortis, orci orci volutpat neque, vitae lobortis lectus
-				elit eget libero. Donec tempus finibus nulla non fringilla. Sed dapibus lacus eu nulla lacinia semper. Integer
-				vitae elementum leo. Aenean neque quam, luctus eu rutrum a, ornare at nisi. Praesent ac erat ac tortor luctus
-				commodo. Sed aliquet nunc quis augue finibus, venenatis dignissim nulla congue. Praesent non nisl turpis. Donec
-				vel faucibus tortor. Aliquam a pulvinar risus. Nam volutpat lobortis odio, sed malesuada neque finibus vel.
-				Curabitur elementum metus ut faucibus scelerisque. Nulla tortor tellus, euismod quis nisi ut, viverra fermentum
-				odio. Phasellus purus magna, eleifend nec erat luctus, mattis vehicula sapien. Donec pretium velit arcu, a posuere
-				justo accumsan sit amet. Nulla luctus rhoncus placerat. Cras efficitur hendrerit tellus, vitae dignissim nisl
-				luctus condimentum. Aliquam id elit vitae lorem lobortis sagittis. Class aptent taciti sociosqu ad litora torquent
-				per conubia nostra, per inceptos himenaeos. Nulla bibendum quis leo id feugiat. Proin id porta massa. Nunc quis
-				maximus felis, auctor malesuada nisl.
-			</div>
+			<Toaster />
+			<div className="signup-container">
+				<h1>회원가입</h1>
+				<div className="signup-box">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam tincidunt elementum facilisis. Duis ac ligula
+					feugiat, tempor tellus sit amet, egestas turpis. Maecenas purus ipsum, porttitor at sodales quis, sollicitudin
+					et ipsum. Donec eleifend et nisi non semper. Nulla id fermentum dui. Vivamus hendrerit erat luctus, tincidunt
+					nisi in, finibus lacus. Aliquam sed arcu non lacus dapibus finibus sit amet sed turpis. Sed pharetra ante eget
+					sollicitudin rhoncus. Integer rhoncus ligula nec congue vulputate. Aenean sed justo ac est scelerisque
+					malesuada. Curabitur laoreet urna sit amet sem porta, et finibus risus convallis. Aenean vitae tortor cursus,
+					vestibulum purus bibendum, efficitur nibh. Suspendisse potenti. Ut nulla elit, posuere id fermentum vitae,
+					efficitur a nunc. Praesent sed mauris pharetra, suscipit magna et, ultricies ligula. Phasellus lacinia ut
+					metus id cursus. Ut tincidunt luctus nisl ut auctor. Pellentesque ullamcorper orci nibh, eu gravida felis
+					tempor a. Integer vel est a mauris pharetra ultrices. Sed consequat vehicula ipsum quis viverra. Phasellus
+					vitae nisl lorem. Praesent dignissim blandit nunc nec consectetur. Nunc vitae metus sit amet lectus vestibulum
+					fermentum. Sed tristique ac nisl a convallis. In molestie, ligula non pellentesque lobortis, orci orci
+					volutpat neque, vitae lobortis lectus elit eget libero. Donec tempus finibus nulla non fringilla. Sed dapibus
+					lacus eu nulla lacinia semper. Integer vitae elementum leo. Aenean neque quam, luctus eu rutrum a, ornare at
+					nisi. Praesent ac erat ac tortor luctus commodo. Sed aliquet nunc quis augue finibus, venenatis dignissim
+					nulla congue. Praesent non nisl turpis. Donec vel faucibus tortor. Aliquam a pulvinar risus. Nam volutpat
+					lobortis odio, sed malesuada neque finibus vel. Curabitur elementum metus ut faucibus scelerisque. Nulla
+					tortor tellus, euismod quis nisi ut, viverra fermentum odio. Phasellus purus magna, eleifend nec erat luctus,
+					mattis vehicula sapien. Donec pretium velit arcu, a posuere justo accumsan sit amet. Nulla luctus rhoncus
+					placerat. Cras efficitur hendrerit tellus, vitae dignissim nisl luctus condimentum. Aliquam id elit vitae
+					lorem lobortis sagittis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos
+					himenaeos. Nulla bibendum quis leo id feugiat. Proin id porta massa. Nunc quis maximus felis, auctor malesuada
+					nisl.
+				</div>
 
-			<label className="signup-label" htmlFor="terms">
-				<input type="checkbox" id="terms" name="terms" value={term ? 'on' : 'off'} onClick={changeTerm} /> 이용약관 동의
-			</label>
-			<div className="signup-horizontal-group">
+				<label className="signup-label" htmlFor="terms">
+					<input type="checkbox" id="terms" name="terms" value={term ? 'on' : 'off'} onClick={changeTerm} /> 이용약관
+					동의
+				</label>
 				<label className="signup-label" htmlFor="username">
-					이름
+					<span>이름</span>
 					<input
 						className="signup-input"
 						type="text"
@@ -78,20 +106,25 @@ const SignUp = () => {
 						onChange={changeName}
 					/>
 				</label>
-				<label className="signup-label" htmlFor="email">
-					이메일
-					<input
-						className="signup-input"
-						type="email"
-						id="email"
-						name="email"
-						maxLength={100}
-						value={email}
-						onChange={changeEmail}
-					/>
-				</label>
+				<div className="signup-horizontal-group">
+					<label className="signup-label" htmlFor="email">
+						<span>이메일</span>
+						<input
+							className="signup-input"
+							type="email"
+							id="email"
+							name="email"
+							maxLength={100}
+							value={email}
+							onChange={changeEmail}
+						/>
+					</label>
+					<button className="signup-submit signup-submit-validate" type="button" tabIndex={0} onClick={checkEamil}>
+						중복확인
+					</button>
+				</div>
+				<input className="signup-submit" type="button" disabled={!isValid()} onClick={submit} value="회원가입" />
 			</div>
-			<input className="signup-submit" type="button" disabled={!term} onClick={submit} value="회원가입" />
 		</form>
 	);
 };

--- a/front/src/pages/trade/sideBar/SideBar.tsx
+++ b/front/src/pages/trade/sideBar/SideBar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import User from '@recoil/user/index';
 import StockList, { IStockListItem } from '@recoil/stockList/index';
 import SideBarItem from './sideBarItem/SideBarItem';
@@ -13,15 +13,41 @@ import SideBarNav, { MENU } from './sideBarNav/SideBarNav';
 
 const SideBar = () => {
 	const [menu, setMenu] = useState(MENU.ALL);
-	const userState = useRecoilValue(User);
+	const [regex, setRegex] = useState(/.*/);
+
+	const [userState] = useRecoilState(User);
 	const stockListState = useRecoilValue(StockList);
 	const [filteredStockListState, setFilteredStockListState] = useState<IStockListItem[]>([]);
-
-	const [regex, setRegex] = useState(/.*/);
 
 	const searchEvent = (event: React.ChangeEvent<HTMLInputElement>) => {
 		setRegex(getRegExp(event?.target?.value));
 	};
+
+	useEffect(() => {
+		fetch(`${process.env.SERVER_URL}/api/user/favorite`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		}).then((res: Response) => {
+			if (res.ok) {
+				userState.favorite = [];
+			}
+		});
+
+		fetch(`${process.env.SERVER_URL}/api/user/hold`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		}).then((res: Response) => {
+			if (res.ok) {
+				userState.hold = [];
+			}
+		});
+	}, [userState]);
 
 	useEffect(() => {
 		setFilteredStockListState(() => {
@@ -65,7 +91,7 @@ const SideBar = () => {
 							regex.test(stock.nameEnglish.toLowerCase()),
 					)
 					.map((stock: IStockListItem) => (
-						<SideBarItem key={stock.stockId} stock={stock} isFavorite={userState.favorite.includes(stock.stockId)} />
+						<SideBarItem key={stock.stockId} stock={stock} />
 					))}
 			</div>
 		</div>

--- a/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.scss
+++ b/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.scss
@@ -5,7 +5,7 @@
 	height: 64px;
 	padding: 0px 4px;
 	box-sizing: border-box;
-	cursor: pointer;
+	cursor: default;
 
 	display: flex;
 	align-items: center;
@@ -50,6 +50,7 @@
 .sidebar__item-favorite {
 	width: 5%;
 	color: $black;
+	cursor: pointer;
 
 	& > svg {
 		margin-top: 4px;

--- a/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.tsx
+++ b/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.tsx
@@ -1,25 +1,21 @@
-import React, { useState } from 'react';
+import React, { MouseEvent, KeyboardEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { AiFillStar } from 'react-icons/ai';
-import { useRecoilState } from 'recoil';
 
-import User from '@recoil/user/index';
 import caretIcon from '@src/common/utils/caretIcon';
 import formatNumber from '@src/common/utils/formatNumber';
 import { IStockListItem } from '@src/recoil/stockList/index';
-
 import './SideBarItem.scss';
 
 export interface Props {
 	stock: IStockListItem;
+	isFavorite: boolean;
+	refresh: () => void;
 }
 
 const SideBarItem = (props: Props) => {
-	const { stock } = props;
+	const { stock, isFavorite, refresh } = props;
 	const { code, nameKorean, price, previousClose, charts } = stock;
-
-	const [userState, setUserState] = useRecoilState(User);
-	const [isFavorite, setFavorite] = useState<boolean>(userState.favorite.includes(stock.stockId));
 
 	const { volume = 0 } = charts.filter(({ type }) => type === 1440)[0] ?? [];
 	const percent = ((price - previousClose) / previousClose) * 100;
@@ -39,15 +35,17 @@ const SideBarItem = (props: Props) => {
 			body: JSON.stringify({ stockCode: code }),
 		}).then((res: Response) => {
 			if (res.ok) {
-				if (isFavorite) {
-					setUserState({ ...userState, favorite: userState.favorite.filter((favorite) => favorite !== stock.stockId) });
-					setFavorite(false);
-				} else {
-					setUserState({ ...userState, favorite: [...userState.favorite, stock.stockId] });
-					setFavorite(true);
-				}
+				res.json().then((data) => {
+					console.log(isFavorite, data);
+				});
+				refresh();
 			}
 		});
+	};
+
+	const toggleFavoriteKey = (event: KeyboardEvent<HTMLDivElement>) => {
+		if (event.type === 'keydown' && event.keyCode !== 13) return;
+		toggleFavorite();
 	};
 
 	return (
@@ -57,7 +55,7 @@ const SideBarItem = (props: Props) => {
 				role="button"
 				tabIndex={0}
 				onClick={toggleFavorite}
-				onKeyDown={toggleFavorite}
+				onKeyDown={toggleFavoriteKey}
 			>
 				<AiFillStar color={isFavorite ? '#FFA800' : '#999'} />
 			</div>

--- a/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.tsx
+++ b/front/src/pages/trade/sideBar/sideBarItem/SideBarItem.tsx
@@ -1,33 +1,64 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AiFillStar } from 'react-icons/ai';
-import caretIcon from '@src/common/utils/caretIcon';
+import { useRecoilState } from 'recoil';
 
+import User from '@recoil/user/index';
+import caretIcon from '@src/common/utils/caretIcon';
+import formatNumber from '@src/common/utils/formatNumber';
 import { IStockListItem } from '@src/recoil/stockList/index';
 
 import './SideBarItem.scss';
-import formatNumber from '@src/common/utils/formatNumber';
 
 export interface Props {
 	stock: IStockListItem;
-	isFavorite: boolean;
 }
 
 const SideBarItem = (props: Props) => {
-	const { stock, isFavorite } = props;
+	const { stock } = props;
 	const { code, nameKorean, price, previousClose, charts } = stock;
 
-	const { volume = 0 } = charts.filter(({ type }) => type === 1440)[0] ?? [];
+	const [userState, setUserState] = useRecoilState(User);
+	const [isFavorite, setFavorite] = useState<boolean>(userState.favorite.includes(stock.stockId));
 
+	const { volume = 0 } = charts.filter(({ type }) => type === 1440)[0] ?? [];
 	const percent = ((price - previousClose) / previousClose) * 100;
+
 	let status = '';
 	if (percent === 0) status = '';
 	else if (percent > 0) status = 'up';
 	else if (percent < 0) status = 'down';
 
+	const toggleFavorite = () => {
+		fetch(`${process.env.SERVER_URL}/api/user/favorite`, {
+			method: isFavorite ? 'DELETE' : 'POST',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json;charset=utf-8',
+			},
+			body: JSON.stringify({ stockCode: code }),
+		}).then((res: Response) => {
+			if (res.ok) {
+				if (isFavorite) {
+					setUserState({ ...userState, favorite: userState.favorite.filter((favorite) => favorite !== stock.stockId) });
+					setFavorite(false);
+				} else {
+					setUserState({ ...userState, favorite: [...userState.favorite, stock.stockId] });
+					setFavorite(true);
+				}
+			}
+		});
+	};
+
 	return (
 		<Link className={`sidebar__item ${status}`} to={`/trade/?code=${code}`}>
-			<div className="sidebar__item-favorite">
+			<div
+				className="sidebar__item-favorite"
+				role="button"
+				tabIndex={0}
+				onClick={toggleFavorite}
+				onKeyDown={toggleFavorite}
+			>
 				<AiFillStar color={isFavorite ? '#FFA800' : '#999'} />
 			</div>
 			<div className="sidebar__item-name">{nameKorean}</div>

--- a/front/src/recoil/user/atom.ts
+++ b/front/src/recoil/user/atom.ts
@@ -1,18 +1,18 @@
 import { atom } from 'recoil';
 
 export interface IUser {
+	username: string;
+	email: string;
 	isLoggedIn: boolean;
-	favorite: number[];
-	hold: number[];
 	theme: 'light' | 'dark';
 }
 
 const userAtom = atom<IUser>({
 	key: 'userAtom',
 	default: {
+		username: '',
+		email: '',
 		isLoggedIn: false,
-		favorite: [],
-		hold: [],
 		theme: 'light',
 	},
 });

--- a/front/src/recoil/user/atom.ts
+++ b/front/src/recoil/user/atom.ts
@@ -11,8 +11,8 @@ const userAtom = atom<IUser>({
 	key: 'userAtom',
 	default: {
 		isLoggedIn: false,
-		favorite: [1],
-		hold: [2],
+		favorite: [],
+		hold: [],
 		theme: 'light',
 	},
 });


### PR DESCRIPTION
## 작업 목록
### 프론트엔드
- 마이 페이지 : 자산현황 및 자산목록을 확인하는 페이지
- 현금입출금 페이지 : 현금입출금 신청 현황 및 신청 폼을 제공하는 페이지
- 사이드바 : 관심종목 토글 기능, 관심종목 및 보유종목 API 로드 기능 추가
- 네비게이션 바 : 로그인 여부에 따라 메뉴가 달리 보이도록 기능 추가
- 기타 : 결정된 API 경로로 경로 수정, 단위 통일을 위해 '개'에서 '주'로 단위 변경
- 구현된 각 기능들에 제공받은 백엔드 API 연결
### 백엔드
- 백엔드 이메일 검증 오류 수정

 ## 특이사항
- 코드 중복.. ㅠㅠ