### PR TITLE
체결 시 호가 정보를 상대적으로 계산하지 않고 서버로 부터 받아서 처리

### DIFF
--- a/front/src/pages/trade/order/Order.tsx
+++ b/front/src/pages/trade/order/Order.tsx
@@ -10,8 +10,8 @@ import ITotalAndMaxAmount from './ITotalAndMaxAmount';
 import './order.scss';
 
 function calculateTotalAndMaxAmount(askOrders: IAskOrderItem[], bidOrders: IBidOrderItem[]): ITotalAndMaxAmount {
-	const totalAskAmount = askOrders.reduce((acc, { price }) => acc + price, 0);
-	const totalBidAmount = bidOrders.reduce((acc, { price }) => acc + price, 0);
+	const totalAskAmount = askOrders.reduce((acc, { amount }) => acc + amount, 0);
+	const totalBidAmount = bidOrders.reduce((acc, { amount }) => acc + amount, 0);
 	const maxAmount = Math.max(...[...askOrders, ...bidOrders].map(({ amount }) => amount));
 
 	return { totalAskAmount, totalBidAmount, maxAmount };


### PR DESCRIPTION
- 기존에는 체결 시 서버에서 넘어오는 체결량을 기반으로 클라이언트에서 차감하는 상대적인 방식으로 호가 정보를 업데이트 하였습니다.
- 이제는 체결 시 호가 API를 통해 서버에서 매수/매도 호가 데이터를 내려주어 클라이언트에서 상대적인 방식으로 계산하지 않고 서버로 부터 받은 데이터를 이용하여 업데이트 하게 됩니다.