### PR TITLE
호가 정보창 스타일 수정

### DIFF
--- a/front/src/pages/trade/Trade.scss
+++ b/front/src/pages/trade/Trade.scss
@@ -62,12 +62,11 @@ $aside-width: 400px;
 .trade-status {
 	display: flex;
 	flex-direction: row;
-	height: fit-content;
+	height: 490px;
 	gap: 0px $gap;
 }
 .trade-order {
 	flex: 1;
-	height: 500px;
 	box-shadow: 2px 2px 4px #dee1e7;
 
 	background-color: $white;

--- a/front/src/pages/trade/bidAsk/bidask.scss
+++ b/front/src/pages/trade/bidAsk/bidask.scss
@@ -237,7 +237,6 @@
 	display: flex;
 	justify-content: space-between;
 	padding: 0 14px;
-	margin: 30px 0 10px;
 
 	@media screen and (max-width: $responsiveSize2) {
 		font-size: 14px;

--- a/front/src/pages/trade/order/Order.tsx
+++ b/front/src/pages/trade/order/Order.tsx
@@ -54,12 +54,16 @@ const Order = ({ previousClose }: IProps) => {
 		const tableHeight = tableElem.offsetHeight;
 		const TABLE_MAX_HEIGHT = 470;
 		const isOrderContentOverflowed = orderContentRef.current.scrollHeight - TABLE_MAX_HEIGHT > 0;
-		let ORDER_CONTENT_LEFT_PADDING_SIZE = '6px';
-		if (!isOrderContentOverflowed) ORDER_CONTENT_LEFT_PADDING_SIZE = '0px';
-
-		orderContentRef.current.style.paddingLeft = ORDER_CONTENT_LEFT_PADDING_SIZE;
+		const ORDER_CONTENT_PADDING_SIZE = 6;
+		const orderContentStyle = orderContentRef.current.style;
 
 		orderContentRef.current.scrollTo(0, (tableHeight - TABLE_MAX_HEIGHT) / 2);
+
+		if (!isOrderContentOverflowed) {
+			orderContentStyle.padding = `0px ${ORDER_CONTENT_PADDING_SIZE}px`;
+			return;
+		}
+		orderContentStyle.padding = `0px 0px 0px ${ORDER_CONTENT_PADDING_SIZE}px`;
 	}, [orderContentRef, askOrders, bidOrders]);
 
 	if (!isOrdersExist(askOrders, bidOrders)) {

--- a/front/src/pages/trade/order/order.scss
+++ b/front/src/pages/trade/order/order.scss
@@ -177,7 +177,7 @@
 	}
 
 	&:hover {
-		background-color: darken($lightBlue, 10%);
+		background-color: darken($darkModeBlue, 10%);
 	}
 
 	.dark-theme & {

--- a/front/src/pages/trade/order/order.scss
+++ b/front/src/pages/trade/order/order.scss
@@ -177,7 +177,7 @@
 	}
 
 	&:hover {
-		background-color: darken($darkModeBlue, 10%);
+		background-color: darken($lightBlue, 10%);
 	}
 
 	.dark-theme & {


### PR DESCRIPTION
1. 다음 사진과 같이 호가 정보가 9개일 때 약간의 틈이 생기는 부분이 거슬려서 제거했습니다:

![화면 캡처 2021-11-19 103554](https://user-images.githubusercontent.com/50892653/142559010-6ea25f90-7a5f-4416-ab10-8c6dc72eef9b.png)

2. 호가 정보창에 스크롤이 있던 없던 일관되게 스타일을 적용했습니다:

(스크롤이 있는 경우)
![화면 캡처 2021-11-19 112223](https://user-images.githubusercontent.com/50892653/142559083-275d34e7-ad6d-415a-aa00-a698fb413796.png)

(스크롤이 없는 경우 - 이번에 바꾼 부분으로 기존엔 호가 잔량 막대가 경계면 끝까지 뻗었었습니다)
![화면 캡처 2021-11-19 112259](https://user-images.githubusercontent.com/50892653/142559177-d64d5658-033d-471e-97e4-4ad54b6aa961.png)

