### PR TITLE
Hotfix: 차트 테이블의 거래량, 거래대금 타입을 INT에서 BIGINT로 변경

### DIFF
--- a/auctioneer/src/models/Chart.ts
+++ b/auctioneer/src/models/Chart.ts
@@ -27,9 +27,9 @@ export default class Chart {
 	@Column({ name: 'price_low' })
 	priceLow: number;
 
-	@Column()
-	amount: number;
+	@Column({ type: 'bigint' })
+	amount: string;
 
-	@Column()
-	volume: number;
+	@Column({ type: 'bigint' })
+	volume: string;
 }

--- a/auctioneer/src/services/BidAskTransaction.ts
+++ b/auctioneer/src/services/BidAskTransaction.ts
@@ -116,8 +116,11 @@ export default class BidAskTransaction implements IBidAskTransaction {
 			chart.priceEnd = this.transactionLog.price;
 			chart.priceHigh = Math.max(chart.priceHigh, this.transactionLog.price);
 			chart.priceLow = Math.min(chart.priceLow, this.transactionLog.price);
-			chart.amount += this.transactionLog.amount;
-			chart.volume += this.transactionLog.price * this.transactionLog.amount;
+
+			const newAmount = BigInt(chart.amount) + BigInt(this.transactionLog.amount);
+			const newVolume = BigInt(chart.volume) + BigInt(this.transactionLog.price) * BigInt(this.transactionLog.amount);
+			chart.amount = newAmount.toString();
+			chart.volume = newVolume.toString();
 			return chart;
 		});
 

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -91,7 +91,7 @@ function updateNonTargetStock(stockList: IStockListItem[], data: INonTargetStock
 				? chartItem
 				: {
 						...chartItem,
-						volume: chartItem.volume + price * amount,
+						volume: (BigInt(chartItem.volume) + BigInt(price * amount)).toString(),
 				  };
 		});
 
@@ -121,8 +121,8 @@ function updateTargetStock(
 				? chartItem
 				: {
 						...chartItem,
-						volume: chartItem.volume + price * amount,
-						amount: chartItem.amount + amount,
+						volume: (BigInt(chartItem.volume) + BigInt(price * amount)).toString(),
+						amount: (BigInt(chartItem.amount) + BigInt(amount)).toString(),
 						priceLow: dailyChartData.priceLow,
 						priceHigh: dailyChartData.priceHigh,
 				  };

--- a/front/src/pages/trade/order/order.scss
+++ b/front/src/pages/trade/order/order.scss
@@ -177,7 +177,7 @@
 	}
 
 	&:hover {
-		background-color: darken($lightBlue, 10%);
+		background-color: darken($darkModeBlue, 10%);
 	}
 
 	.dark-theme & {

--- a/front/src/pages/trade/order/order.scss
+++ b/front/src/pages/trade/order/order.scss
@@ -177,7 +177,7 @@
 	}
 
 	&:hover {
-		background-color: darken($darkModeBlue, 10%);
+		background-color: darken($lightBlue, 10%);
 	}
 
 	.dark-theme & {

--- a/front/src/recoil/stockList/atom.ts
+++ b/front/src/recoil/stockList/atom.ts
@@ -8,8 +8,8 @@ export interface IStockChartItem {
 	priceEnd: number;
 	priceLow: number;
 	priceHigh: number;
-	volume: number;
-	amount: number;
+	volume: string;
+	amount: string;
 }
 
 export interface IStockListItem {


### PR DESCRIPTION
- INT로 하니까 21억이 넘어가서 오버플로우가 발생합니다!! BIGINT로 변경했습니다~
- typeorm에서 bigint는 string으로 취급한다길래 model에서 해당 컬럼들의 타입을 number에서 string으로 변경했습니다~