### PR TITLE
주문 체결 로직 수정

### DIFF
--- a/auctioneer/src/models/Chart.ts
+++ b/auctioneer/src/models/Chart.ts
@@ -27,9 +27,9 @@ export default class Chart {
 	@Column({ name: 'price_low' })
 	priceLow: number;
 
-	@Column({ type: 'bigint' })
-	amount: string;
+	@Column()
+	amount: number;
 
-	@Column({ type: 'bigint' })
-	volume: string;
+	@Column()
+	volume: number;
 }

--- a/auctioneer/src/services/AuctioneerService.ts
+++ b/auctioneer/src/services/AuctioneerService.ts
@@ -27,13 +27,13 @@ export default class AuctioneerService {
 			const OrderRepositoryRunner = queryRunner.manager.getCustomRepository(OrderRepository);
 			const ChartRepositoryRunner = queryRunner.manager.getCustomRepository(ChartRepository);
 
-			const [stock, orderAsk, orderBid]: [Stock | undefined, Order | undefined, Order | undefined] = await Promise.all([
+			const [stock, orderBid, orderAsk]: [Stock | undefined, Order | undefined, Order | undefined] = await Promise.all([
 				StockRepositoryRunner.readStockById(stockId),
 				OrderRepositoryRunner.readOrderByDesc(stockId, ORDERTYPE.BID),
 				OrderRepositoryRunner.readOrderByAsc(stockId, ORDERTYPE.ASK),
 			]);
 
-			if (stock === undefined || orderAsk === undefined || orderBid === undefined || orderBid.price > orderAsk.price)
+			if (stock === undefined || orderAsk === undefined || orderBid === undefined || orderAsk.price > orderBid.price)
 				throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
 
 			const task = new BidAskTransaction(
@@ -65,6 +65,7 @@ export default class AuctioneerService {
 				task.bidOrderProcess(bidUser, bidUserStock, orderBid),
 				task.askOrderProcess(askUser, askUserStock, orderAsk),
 			]);
+
 			await task.noticeProcess(stock);
 			queryRunner.commitTransaction();
 			result = true;

--- a/auctioneer/src/services/BidAskTransaction.ts
+++ b/auctioneer/src/services/BidAskTransaction.ts
@@ -118,11 +118,8 @@ export default class BidAskTransaction implements IBidAskTransaction {
 			chart.priceEnd = this.transactionLog.price;
 			chart.priceHigh = Math.max(chart.priceHigh, this.transactionLog.price);
 			chart.priceLow = Math.min(chart.priceLow, this.transactionLog.price);
-
-			const newAmount = BigInt(chart.amount) + BigInt(this.transactionLog.amount);
-			const newVolume = BigInt(chart.volume) + BigInt(this.transactionLog.price) * BigInt(this.transactionLog.amount);
-			chart.amount = newAmount.toString();
-			chart.volume = newVolume.toString();
+			chart.amount += this.transactionLog.amount;
+			chart.volume += this.transactionLog.price * this.transactionLog.amount;
 			return chart;
 		});
 

--- a/auctioneer/src/services/BidAskTransaction.ts
+++ b/auctioneer/src/services/BidAskTransaction.ts
@@ -60,26 +60,8 @@ export default class BidAskTransaction implements IBidAskTransaction {
 
 	async askOrderProcess(askUser: User, askUserStock: UserStock | undefined, askOrder: Order): Promise<void | Error> {
 		this.transactionLog.askUser = askUser.userId;
-		if (askUserStock === undefined) {
-			const newUserStock = this.UserStockRepositoryRunner.create({
-				userId: askOrder.userId,
-				stockId: askOrder.stockId,
-				amount: this.transactionLog.amount,
-				average: askOrder.price,
-			});
-			this.UserStockRepositoryRunner.insert(newUserStock);
-		} else {
-			askUserStock.amount += this.transactionLog.amount;
-			askUserStock.average = getAveragePrice(
-				askUserStock.amount,
-				askUserStock.average,
-				this.transactionLog.amount,
-				this.transactionLog.price,
-			);
-			await this.UserStockRepositoryRunner.save(askUserStock);
-		}
-		// 매수주문이랑 실제거래가가 차이있을 때 잔돈 반환하는 로직
-		askUser.balance += (askOrder.price - this.transactionLog.price) * this.transactionLog.amount;
+		this.transactionLog.stockId = askOrder.stockId;
+		askUser.balance += this.transactionLog.amount * this.transactionLog.price;
 		await this.UserRepositoryRunner.save(askUser);
 
 		askOrder.amount -= this.transactionLog.amount;
@@ -90,8 +72,28 @@ export default class BidAskTransaction implements IBidAskTransaction {
 	async bidOrderProcess(bidUser: User, bidUserStock: UserStock | undefined, bidOrder: Order): Promise<void | Error> {
 		this.transactionLog.bidUser = bidUser.userId;
 		this.transactionLog.stockId = bidOrder.stockId;
-		bidUser.balance += this.transactionLog.amount * this.transactionLog.price;
+		// 매수주문이랑 실제거래가가 차이있을 때 잔돈 반환하는 로직
+		bidUser.balance += (bidOrder.price - this.transactionLog.price) * this.transactionLog.amount;
 		await this.UserRepositoryRunner.save(bidUser);
+
+		if (bidUserStock === undefined) {
+			const newUserStock = this.UserStockRepositoryRunner.create({
+				userId: bidOrder.userId,
+				stockId: bidOrder.stockId,
+				amount: this.transactionLog.amount,
+				average: bidOrder.price,
+			});
+			this.UserStockRepositoryRunner.insert(newUserStock);
+		} else {
+			bidUserStock.amount += this.transactionLog.amount;
+			bidUserStock.average = getAveragePrice(
+				bidUserStock.amount,
+				bidUserStock.average,
+				this.transactionLog.amount,
+				this.transactionLog.price,
+			);
+			await this.UserStockRepositoryRunner.save(bidUserStock);
+		}
 
 		bidOrder.amount -= this.transactionLog.amount;
 		if (bidOrder.amount === 0) await this.OrderRepositoryRunner.remove(bidOrder);

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -91,7 +91,7 @@ function updateNonTargetStock(stockList: IStockListItem[], data: INonTargetStock
 				? chartItem
 				: {
 						...chartItem,
-						volume: (BigInt(chartItem.volume) + BigInt(price * amount)).toString(),
+						volume: chartItem.volume + price * amount,
 				  };
 		});
 
@@ -121,8 +121,8 @@ function updateTargetStock(
 				? chartItem
 				: {
 						...chartItem,
-						volume: (BigInt(chartItem.volume) + BigInt(price * amount)).toString(),
-						amount: (BigInt(chartItem.amount) + BigInt(amount)).toString(),
+						volume: chartItem.volume + price * amount,
+						amount: chartItem.amount + amount,
 						priceLow: dailyChartData.priceLow,
 						priceHigh: dailyChartData.priceHigh,
 				  };

--- a/front/src/recoil/stockList/atom.ts
+++ b/front/src/recoil/stockList/atom.ts
@@ -8,8 +8,8 @@ export interface IStockChartItem {
 	priceEnd: number;
 	priceLow: number;
 	priceHigh: number;
-	volume: string;
-	amount: string;
+	volume: number;
+	amount: number;
 }
 
 export interface IStockListItem {


### PR DESCRIPTION
- 매수 로직과 매도 로직이 서로 거꾸로 되어 있는것 같아 수정하였습니다. 한번 봐주시면 좋을 것 같습니다!
- 그리고 현재 유저 테이블의 `balance` 컬럼이 INT 타입이라 체결 중에 오버플로우가 발생하여 체결이 멈추는 버그가 있는 것 같습니다. 
- 일단은 unsigned INT로 바꿔놓았지만 이 컬럼의 타입도 BIGINT로 바꿔야할 듯 합니다. typeorm은 BIGINT를 string으로 취급하기 때문에 지금 바꿨다가 에러가 날 것 같아 일단은 보류했습니다.