### PR TITLE
Auctioneer 개선 사항 반영

### DIFF
--- a/auctioneer/src/api/message/message.ts
+++ b/auctioneer/src/api/message/message.ts
@@ -2,6 +2,7 @@
 import express, { NextFunction, Request, Response } from 'express';
 import { AuctioneerService } from '@services/index';
 import { ParamError, ParamErrorMessage } from '@errors/index';
+import eventEmitter from '@helper/eventEmitter';
 
 export default (): express.Router => {
 	const router = express.Router();
@@ -10,9 +11,8 @@ export default (): express.Router => {
 		try {
 			const { code } = req.query;
 			if (code === undefined) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
-			const autioneerServiceInstance = new AuctioneerService();
-			res.status(200).json({});
-			while (await autioneerServiceInstance.bidAsk(code as string));
+			eventEmitter.emit('waiting');
+			res.end();
 		} catch (error) {
 			next(error);
 		}

--- a/auctioneer/src/api/message/message.ts
+++ b/auctioneer/src/api/message/message.ts
@@ -11,7 +11,7 @@ export default (): express.Router => {
 		try {
 			const { code } = req.query;
 			if (code === undefined) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
-			eventEmitter.emit('waiting');
+			eventEmitter.emit('waiting', code);
 			res.end();
 		} catch (error) {
 			next(error);

--- a/auctioneer/src/helper/eventEmitter.ts
+++ b/auctioneer/src/helper/eventEmitter.ts
@@ -1,0 +1,5 @@
+import EventEmitter from 'events';
+
+const eventEmitter = new EventEmitter();
+
+export default eventEmitter;

--- a/auctioneer/src/loaders/index.ts
+++ b/auctioneer/src/loaders/index.ts
@@ -5,6 +5,7 @@ import expressLoader from './express';
 import typeormLoader from './typeorm';
 import mongooseLoader from './mongoose';
 import chartLogger from './chartLogger';
+import './matchLogger';
 import Logger from './logger';
 
 export default async ({ expressApp }: { expressApp: Application }): Promise<void> => {

--- a/auctioneer/src/loaders/index.ts
+++ b/auctioneer/src/loaders/index.ts
@@ -5,7 +5,7 @@ import expressLoader from './express';
 import typeormLoader from './typeorm';
 import mongooseLoader from './mongoose';
 import chartLogger from './chartLogger';
-import './matchLogger';
+import auctioneerLoader from './matchLogger';
 import Logger from './logger';
 
 export default async ({ expressApp }: { expressApp: Application }): Promise<void> => {
@@ -15,6 +15,8 @@ export default async ({ expressApp }: { expressApp: Application }): Promise<void
 	Logger.info('✌️ Typeorm loaded');
 	await mongooseLoader();
 	Logger.info('✌️ Mongoose loaded');
+	await auctioneerLoader();
+	Logger.info('✌️ Auctioneer loaded');
 	if (config.instanceId === 0) {
 		chartLogger();
 		Logger.info('✌️ ChartLogger loaded');

--- a/auctioneer/src/loaders/matchLogger.ts
+++ b/auctioneer/src/loaders/matchLogger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import EventEmitter from '@helper/eventEmitter';
 import AuctioneerService from '@services/AuctioneerService';
 
@@ -16,6 +17,7 @@ const quitAuctioneer = (stockCode) => {
 };
 const runAuctioneer = async (): Promise<void> => {
 	const stockCode = waitingQueue.pop();
+	if (!stockCode) return;
 
 	startAuctioneer(stockCode);
 	while (await auctioneerServiceInstance.bidAsk(stockCode));
@@ -26,8 +28,10 @@ const runAuctioneer = async (): Promise<void> => {
 
 EventEmitter.on('waiting', (stockCode: string): void => {
 	if (runningState === stockCode || waitingSet.has(stockCode)) return;
+
 	waitingQueue.unshift(stockCode);
 	waitingSet.add(stockCode);
+
 	if (!runningState) runAuctioneer();
 });
 

--- a/auctioneer/src/loaders/matchLogger.ts
+++ b/auctioneer/src/loaders/matchLogger.ts
@@ -4,9 +4,9 @@ import StockRepository from '@repositories/StockRepository';
 import AuctioneerService from '@services/AuctioneerService';
 import { getCustomRepository } from 'typeorm';
 
+const waitingSet = {};
 const auctioneerServiceInstance = new AuctioneerService();
 
-const waitingSet = {};
 const auctioneerLoader = async (): Promise<void> => {
 	const stockRepository = getCustomRepository(StockRepository);
 	const stockCodeList = await stockRepository.readStockCodeList();

--- a/auctioneer/src/loaders/matchLogger.ts
+++ b/auctioneer/src/loaders/matchLogger.ts
@@ -1,0 +1,34 @@
+import EventEmitter from '@helper/eventEmitter';
+import AuctioneerService from '@services/AuctioneerService';
+
+const auctioneerServiceInstance = new AuctioneerService();
+
+let runningState = '';
+const waitingQueue: string[] = [];
+const waitingSet = new Set();
+
+const startAuctioneer = (stockCode) => {
+	runningState = stockCode;
+};
+const quitAuctioneer = (stockCode) => {
+	runningState = '';
+	waitingSet.delete(stockCode);
+};
+const runAuctioneer = async (): Promise<void> => {
+	const stockCode = waitingQueue.pop();
+
+	startAuctioneer(stockCode);
+	while (await auctioneerServiceInstance.bidAsk(stockCode));
+	quitAuctioneer(stockCode);
+
+	if (waitingQueue.length) runAuctioneer();
+};
+
+EventEmitter.on('waiting', (stockCode: string): void => {
+	if (runningState === stockCode || waitingSet.has(stockCode)) return;
+	waitingQueue.unshift(stockCode);
+	waitingSet.add(stockCode);
+	if (!runningState) runAuctioneer();
+});
+
+export default runAuctioneer;

--- a/auctioneer/src/models/Order.ts
+++ b/auctioneer/src/models/Order.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-cycle */
 import 'reflect-metadata';
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, VersionColumn } from 'typeorm';
 import { Stock } from './index';
 
 export enum ORDERTYPE {
@@ -41,4 +41,7 @@ export default class Order {
 
 	@Column({ name: 'created_at' })
 	createdAt: Date;
+
+	@VersionColumn()
+	version: number;
 }

--- a/auctioneer/src/models/UserStock.ts
+++ b/auctioneer/src/models/UserStock.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-cycle */
 import 'reflect-metadata';
-import { Entity, Column, PrimaryGeneratedColumn, JoinColumn, ManyToOne } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, JoinColumn, ManyToOne, VersionColumn } from 'typeorm';
 import { Stock, User } from './index';
 
 @Entity({ name: 'user_stock' })
@@ -21,4 +21,7 @@ export default class UserStock {
 
 	@Column()
 	average: number;
+
+	@VersionColumn()
+	readonly version: number;
 }

--- a/auctioneer/src/repositories/ChartRepository.ts
+++ b/auctioneer/src/repositories/ChartRepository.ts
@@ -7,7 +7,7 @@ export default class ChartRepository extends Repository<Chart> {
 		return this.find({
 			where: { type },
 			relations: ['stock'],
-			lock: { mode: 'pessimistic_write' },
+			// lock: { mode: 'pessimistic_write' },
 		});
 	}
 }

--- a/auctioneer/src/repositories/OrderRepository.ts
+++ b/auctioneer/src/repositories/OrderRepository.ts
@@ -4,28 +4,37 @@ import { Order, ORDERTYPE } from '@models/index';
 @EntityRepository(Order)
 export default class OrderRepository extends Repository<Order> {
 	public async readAskOrderByCode(code: string): Promise<Order | undefined> {
-		return (
-			this.createQueryBuilder('Order')
-				.innerJoin('Order.stock', 'Stock')
-				.where('Stock.code = :code', { code })
-				.andWhere('Order.type = :type', { type: ORDERTYPE.ASK })
-				.orderBy('Order.price', 'ASC')
-				.addOrderBy('Order.createdAt', 'ASC')
-				// .setLock('pessimistic_write')
-				.getOneOrFail()
-		);
+		return this.createQueryBuilder('Order')
+			.innerJoin('Order.stock', 'Stock')
+			.where('Stock.code = :code', { code })
+			.andWhere('Order.type = :type', { type: ORDERTYPE.ASK })
+			.orderBy('Order.price', 'ASC')
+			.addOrderBy('Order.createdAt', 'ASC')
+			.getOneOrFail();
 	}
 
 	public async readBidOrderByCode(code: string): Promise<Order | undefined> {
-		return (
-			this.createQueryBuilder('Order')
-				.innerJoin('Order.stock', 'Stock')
-				.where('Stock.code = :code', { code })
-				.andWhere('Order.type = :type', { type: ORDERTYPE.BID })
-				.orderBy('Order.price', 'DESC')
-				.addOrderBy('Order.createdAt', 'ASC')
-				// .setLock('pessimistic_write')
-				.getOne()
-		);
+		return this.createQueryBuilder('Order')
+			.innerJoin('Order.stock', 'Stock')
+			.where('Stock.code = :code', { code })
+			.andWhere('Order.type = :type', { type: ORDERTYPE.BID })
+			.orderBy('Order.price', 'DESC')
+			.addOrderBy('Order.createdAt', 'ASC')
+			.getOne();
+	}
+
+	public async removeOrder(order: Order): Promise<void> {
+		this.createQueryBuilder().delete().from(Order).where('order_id = :orderId', { orderId: order.orderId }).execute();
+	}
+
+	public async updateOrder(order: Order, amount: number): Promise<void> {
+		this.createQueryBuilder()
+			.setLock('optimistic', 0)
+			.update(Order)
+			.set({
+				amount: () => `amount - ${amount}`,
+			})
+			.where('order_id = :orderId', { orderId: order.orderId })
+			.execute();
 	}
 }

--- a/auctioneer/src/repositories/OrderRepository.ts
+++ b/auctioneer/src/repositories/OrderRepository.ts
@@ -4,24 +4,28 @@ import { Order, ORDERTYPE } from '@models/index';
 @EntityRepository(Order)
 export default class OrderRepository extends Repository<Order> {
 	public async readAskOrderByCode(code: string): Promise<Order | undefined> {
-		return this.createQueryBuilder('Order')
-			.innerJoin('Order.stock', 'Stock')
-			.where('Stock.code = :code', { code })
-			.andWhere('Order.type = :type', { type: ORDERTYPE.ASK })
-			.orderBy('Order.price', 'ASC')
-			.addOrderBy('Order.createdAt', 'ASC')
-			.setLock('pessimistic_write')
-			.getOneOrFail();
+		return (
+			this.createQueryBuilder('Order')
+				.innerJoin('Order.stock', 'Stock')
+				.where('Stock.code = :code', { code })
+				.andWhere('Order.type = :type', { type: ORDERTYPE.ASK })
+				.orderBy('Order.price', 'ASC')
+				.addOrderBy('Order.createdAt', 'ASC')
+				// .setLock('pessimistic_write')
+				.getOneOrFail()
+		);
 	}
 
 	public async readBidOrderByCode(code: string): Promise<Order | undefined> {
-		return this.createQueryBuilder('Order')
-			.innerJoin('Order.stock', 'Stock')
-			.where('Stock.code = :code', { code })
-			.andWhere('Order.type = :type', { type: ORDERTYPE.BID })
-			.orderBy('Order.price', 'DESC')
-			.addOrderBy('Order.createdAt', 'ASC')
-			.setLock('pessimistic_write')
-			.getOne();
+		return (
+			this.createQueryBuilder('Order')
+				.innerJoin('Order.stock', 'Stock')
+				.where('Stock.code = :code', { code })
+				.andWhere('Order.type = :type', { type: ORDERTYPE.BID })
+				.orderBy('Order.price', 'DESC')
+				.addOrderBy('Order.createdAt', 'ASC')
+				// .setLock('pessimistic_write')
+				.getOne()
+		);
 	}
 }

--- a/auctioneer/src/repositories/StockRepository.ts
+++ b/auctioneer/src/repositories/StockRepository.ts
@@ -5,14 +5,14 @@ import Stock from '@models/Stock';
 export default class StockRepository extends Repository<Stock> {
 	public async readStockById(id: number): Promise<Stock | undefined> {
 		return this.findOne(id, {
-			lock: { mode: 'pessimistic_write' },
+			// lock: { mode: 'pessimistic_write' },
 		});
 	}
 
 	public async readStockByCode(code: string): Promise<Stock | undefined> {
 		return this.findOne({
 			where: { code },
-			lock: { mode: 'pessimistic_write' },
+			// lock: { mode: 'pessimistic_write' },
 		});
 	}
 }

--- a/auctioneer/src/repositories/StockRepository.ts
+++ b/auctioneer/src/repositories/StockRepository.ts
@@ -15,4 +15,9 @@ export default class StockRepository extends Repository<Stock> {
 			// lock: { mode: 'pessimistic_write' },
 		});
 	}
+
+	public async readStockCodeList(): Promise<{ code: string }[]> {
+		const stockCodeList = await this.createQueryBuilder().select(['code']).getRawMany();
+		return stockCodeList;
+	}
 }

--- a/auctioneer/src/repositories/UserStockRepository.ts
+++ b/auctioneer/src/repositories/UserStockRepository.ts
@@ -14,7 +14,6 @@ export default class UserStockRepository extends Repository<UserStock> {
 			.leftJoin('UserStock.user', 'User')
 			.where('User.userId=:userId', { userId })
 			.andWhere('Stock.code=:code', { code })
-			.setLock('optimistic', 0)
 			.getOne();
 	}
 }

--- a/auctioneer/src/repositories/UserStockRepository.ts
+++ b/auctioneer/src/repositories/UserStockRepository.ts
@@ -10,9 +10,11 @@ export default class UserStockRepository extends Repository<UserStock> {
 
 	async readUserStockByCode(userId: number, code: string): Promise<UserStock | undefined> {
 		return this.createQueryBuilder('UserStock')
-			.leftJoin('UserStock.stock', 'Stock', 'Stock.code = :code', { code })
-			.leftJoin('UserStock.user', 'User', 'User.userId = :userId', { userId })
-			.setLock('pessimistic_write')
+			.leftJoin('UserStock.stock', 'Stock')
+			.leftJoin('UserStock.user', 'User')
+			.where('User.userId=:userId', { userId })
+			.andWhere('Stock.code=:code', { code })
+			.setLock('optimistic', 0)
 			.getOne();
 	}
 }

--- a/auctioneer/src/services/AuctioneerService.ts
+++ b/auctioneer/src/services/AuctioneerService.ts
@@ -69,7 +69,6 @@ export default class AuctioneerService {
 			await task.logProcess();
 			result = true;
 		} catch (err) {
-			console.log(err);
 			await queryRunner.rollbackTransaction();
 			result = false;
 		} finally {

--- a/auctioneer/src/services/AuctioneerService.ts
+++ b/auctioneer/src/services/AuctioneerService.ts
@@ -40,7 +40,7 @@ export default class AuctioneerService {
 			]);
 			if (askUser === undefined || bidUser === undefined) throw new OrderError(OrderErrorMessage.NO_ORDERS_AVAILABLE);
 			const bidUserStock = await UserStockRepositoryRunner.readUserStockByCode(bidUser.userId, code);
-
+			console.log(bidUserStock);
 			const task = new BidAskTransaction(
 				StockRepositoryRunner,
 				UserRepositoryRunner,
@@ -69,6 +69,7 @@ export default class AuctioneerService {
 			queryRunner.commitTransaction();
 			result = true;
 		} catch (err) {
+			console.log(err);
 			queryRunner.rollbackTransaction();
 			result = false;
 		} finally {

--- a/auctioneer/src/services/AuctioneerService.ts
+++ b/auctioneer/src/services/AuctioneerService.ts
@@ -62,7 +62,7 @@ export default class AuctioneerService {
 			await Promise.all([
 				task.bidOrderProcess(bidUser, bidUserStock, orderBid),
 				task.askOrderProcess(askUser, orderAsk),
-				task.chartProcess(stock),
+				// task.chartProcess(stock),
 			]);
 			await task.logProcess();
 

--- a/auctioneer/src/services/AuctioneerService.ts
+++ b/auctioneer/src/services/AuctioneerService.ts
@@ -62,7 +62,7 @@ export default class AuctioneerService {
 			await Promise.all([
 				task.bidOrderProcess(bidUser, bidUserStock, orderBid),
 				task.askOrderProcess(askUser, orderAsk),
-				// task.chartProcess(stock),
+				task.chartProcess(stock),
 			]);
 			await task.logProcess();
 

--- a/auctioneer/src/services/BidAskTransaction.ts
+++ b/auctioneer/src/services/BidAskTransaction.ts
@@ -71,7 +71,7 @@ export default class BidAskTransaction {
 		if (bidUserStock === undefined) {
 			const newUserStock = this.UserStockRepositoryRunner.create({
 				user: bidUser,
-				stock: bidOrder.stock,
+				stock: bidOrder,
 				amount: this.TransactionInfo.amount,
 				average: bidOrder.price,
 			});

--- a/auctioneer/src/services/BidAskTransaction.ts
+++ b/auctioneer/src/services/BidAskTransaction.ts
@@ -56,9 +56,11 @@ export default class BidAskTransaction {
 		askUser.balance += this.TransactionInfo.amount * this.TransactionInfo.price;
 		await this.UserRepositoryRunner.save(askUser);
 
-		askOrder.amount -= this.TransactionInfo.amount;
-		if (askOrder.amount === 0) await this.OrderRepositoryRunner.remove(askOrder);
-		else await this.OrderRepositoryRunner.save(askOrder);
+		if (askOrder.amount === this.TransactionInfo.amount) {
+			await this.OrderRepositoryRunner.removeOrder(askOrder);
+		} else {
+			await this.OrderRepositoryRunner.updateOrder(askOrder, this.TransactionInfo.amount);
+		}
 	}
 
 	async bidOrderProcess(bidUser: User, bidUserStock: UserStock | undefined, bidOrder: Order): Promise<void | Error> {
@@ -87,9 +89,11 @@ export default class BidAskTransaction {
 			await this.UserStockRepositoryRunner.save(bidUserStock);
 		}
 
-		bidOrder.amount -= this.TransactionInfo.amount;
-		if (bidOrder.amount === 0) await this.OrderRepositoryRunner.remove(bidOrder);
-		else await this.OrderRepositoryRunner.save(bidOrder);
+		if (bidOrder.amount === this.TransactionInfo.amount) {
+			await this.OrderRepositoryRunner.removeOrder(bidOrder);
+		} else {
+			await this.OrderRepositoryRunner.updateOrder(bidOrder, this.TransactionInfo.amount);
+		}
 	}
 
 	async chartProcess(stock: Stock): Promise<void | Error> {
@@ -140,7 +144,6 @@ export default class BidAskTransaction {
 				},
 				body: JSON.stringify({
 					match: {
-						// document??
 						id: document.id,
 						stockId: this.TransactionInfo.stockId,
 						bidUser: this.TransactionInfo.bidUser,

--- a/back/src/api/stock/stock.ts
+++ b/back/src/api/stock/stock.ts
@@ -1,21 +1,28 @@
 import OrderService from '@services/OrderService';
+import StockService from '@services/StockService';
 import express, { Request, Response } from 'express';
 import Emitter from '../../helper/eventEmitter';
 
 export default (): express.Router => {
 	const router = express.Router();
 	router.post('/conclusion', async (req: Request, res: Response) => {
+		res.end();
 		const msg = req.body;
 		const orderServiceInstance = new OrderService();
 		const { code: stockCode, stockId } = msg.match;
 		msg.bidAsk = await orderServiceInstance.getBidAskOrders(stockId);
 		const { bidUser, askUser, ...matchMessage } = msg.match;
 		const broadcastMessage = { ...msg, match: matchMessage };
-		res.end();
 
 		Emitter.emit('broadcast', { stockCode, msg: broadcastMessage });
 		Emitter.emit('notice', bidUser, { userType: 'bid', stockCode });
 		Emitter.emit('notice', askUser, { userType: 'ask', stockCode });
+	});
+
+	router.get('/prices', async (req: Request, res: Response) => {
+		const stockService = new StockService();
+		const stockList = await stockService.getPriceStockAll();
+		res.status(200).json({ stocks: stockList });
 	});
 
 	return router;

--- a/back/src/loaders/express.ts
+++ b/back/src/loaders/express.ts
@@ -10,13 +10,6 @@ import loggers from '@loaders/logger';
 import session from './session';
 
 export default async ({ app }: { app: express.Application }): Promise<void> => {
-	app.get('/status', (req, res) => {
-		res.status(200).end();
-	});
-	app.head('/status', (req, res) => {
-		res.status(200).end();
-	});
-
 	app.enable('trust proxy');
 	app.use(morgan('tiny'));
 	app.use(cors({ origin: [config.clientURL, 'http://127.0.0.1'], credentials: true }));

--- a/back/src/repositories/OrderRepository.ts
+++ b/back/src/repositories/OrderRepository.ts
@@ -7,7 +7,7 @@ import { IBidOrder } from '@interfaces/bidOrder';
 export default class OrderRepository extends Repository<Order> {
 	public async readOrderById(id: number): Promise<Order | undefined> {
 		return this.findOne(id, {
-			lock: { mode: 'pessimistic_write' },
+			// lock: { mode: 'pessimistic_write' },
 		});
 	}
 

--- a/back/src/repositories/StockRepository.ts
+++ b/back/src/repositories/StockRepository.ts
@@ -16,14 +16,14 @@ export default class StockRepository extends Repository<Stock> {
 
 	public async readStockById(id: number): Promise<Stock | undefined> {
 		return this.findOne(id, {
-			lock: { mode: 'pessimistic_write' },
+			// lock: { mode: 'pessimistic_write' },
 		});
 	}
 
 	public async readStockByCode(code: string): Promise<Stock | undefined> {
 		return this.findOne({
 			where: { code },
-			lock: { mode: 'pessimistic_write' },
+			// lock: { mode: 'pessimistic_write' },
 		});
 	}
 
@@ -39,6 +39,10 @@ export default class StockRepository extends Repository<Stock> {
 	public async readStockBaseInfo(): Promise<{ stock_id: number; code: string }[]> {
 		const baseInfo = await this.createQueryBuilder().select(['stock_id', 'code']).getRawMany();
 		return baseInfo;
-		// return this.createQueryBuilder().select('price').where('stock_id = :stockId', { stockId }).getRawOne();
+	}
+
+	public async readPriceStocks(): Promise<{ code: string; price: number }[]> {
+		const stockPrices = await this.createQueryBuilder().select(['code', 'price']).getRawMany();
+		return stockPrices;
 	}
 }

--- a/back/src/services/OrderService.ts
+++ b/back/src/services/OrderService.ts
@@ -114,6 +114,7 @@ export default class OrderService {
 			await orderRepository.remove(order);
 			await queryRunner.commitTransaction();
 		} catch (error) {
+			console.log(error);
 			await queryRunner.rollbackTransaction();
 			throw error;
 		} finally {

--- a/back/src/services/OrderService.ts
+++ b/back/src/services/OrderService.ts
@@ -66,7 +66,6 @@ export default class OrderService {
 			);
 			await queryRunner.commitTransaction();
 		} catch (error) {
-			console.log(error);
 			await queryRunner.rollbackTransaction();
 			throw error;
 		} finally {

--- a/back/src/services/OrderService.ts
+++ b/back/src/services/OrderService.ts
@@ -66,6 +66,7 @@ export default class OrderService {
 			);
 			await queryRunner.commitTransaction();
 		} catch (error) {
+			console.log(error);
 			await queryRunner.rollbackTransaction();
 			throw error;
 		} finally {

--- a/back/src/services/OrderService.ts
+++ b/back/src/services/OrderService.ts
@@ -114,7 +114,6 @@ export default class OrderService {
 			await orderRepository.remove(order);
 			await queryRunner.commitTransaction();
 		} catch (error) {
-			console.log(error);
 			await queryRunner.rollbackTransaction();
 			throw error;
 		} finally {

--- a/back/src/services/StockService.ts
+++ b/back/src/services/StockService.ts
@@ -20,22 +20,6 @@ export default class StockService {
 		StockService.instance = this;
 	}
 
-	// static async getStockCodeById(id: number): Promise<string> {
-	// 	if (id === undefined) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
-	// 	const stockRepository: StockRepository = getCustomRepository(StockRepository);
-	// 	const stock = await stockRepository.findOne(id);
-	// 	if (stock === undefined) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
-	// 	return stock.code;
-	// }
-
-	// static async getStockIdByCode(code: string): Promise<number> {
-	// 	if (code === undefined) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
-	// 	const stockRepository: StockRepository = getCustomRepository(StockRepository);
-	// 	const stock = await stockRepository.findOne({ where: { code } });
-	// 	if (stock === undefined) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
-	// 	return stock.stockId;
-	// }
-
 	public async getCurrentStockPrice(entityManager: EntityManager, stockId: number): Promise<{ price: number }> {
 		const stockRepository: StockRepository = this.getStockRepository(entityManager);
 

--- a/back/src/services/StockService.ts
+++ b/back/src/services/StockService.ts
@@ -79,7 +79,7 @@ export default class StockService {
 	}
 
 	public async getStocksBaseInfo(): Promise<{ stock_id: number; code: string }[]> {
-		const connection = await createConnection();
+		const connection = await getConnection();
 		const stockRepository = connection.getCustomRepository(StockRepository);
 		const baseInfo = await stockRepository.readStockBaseInfo();
 
@@ -113,5 +113,12 @@ export default class StockService {
 		} finally {
 			await queryRunner.release();
 		}
+	}
+
+	public async getPriceStockAll(): Promise<{ code: string; price: number }[]> {
+		const connection = await getConnection();
+		const stockRepository = connection.getCustomRepository(StockRepository);
+		const stockPrices = await stockRepository.readPriceStocks();
+		return stockPrices;
 	}
 }

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -242,7 +242,6 @@ const startSocket = ({ setSocket, setStockList, setStockExecution, setAskOrders,
 
 					Emitter.emit('order concluded', matchData.code);
 				}
-				setHold(await getHoldStocks());
 				break;
 			}
 			case 'baseStock': {
@@ -268,6 +267,7 @@ const startSocket = ({ setSocket, setStockList, setStockExecution, setAskOrders,
 							<p>&nbsp;매도 주문 체결되었습니다.</p>
 						</>,
 					);
+				setHold(await getHoldStocks());
 				break;
 			}
 			default:

--- a/front/src/app.tsx
+++ b/front/src/app.tsx
@@ -50,7 +50,7 @@ const App: React.FC = () => {
 
 	return (
 		<BrowserRouter>
-			<Toaster />
+			<Toaster position="bottom-left" reverseOrder={false} />
 			<Theme>
 				<TopBar pages={pages} />
 				<Switch>

--- a/front/src/pages/trade/Trade.scss
+++ b/front/src/pages/trade/Trade.scss
@@ -82,7 +82,7 @@ $aside-width: 400px;
 	min-height: 400px;
 	background-color: $white;
 	box-shadow: 2px 2px 4px #dee1e7;
-
+	border-radius: 6px;
 	@include darkModeCardStyle();
 }
 

--- a/front/src/pages/trade/conclusion/Conclusion.tsx
+++ b/front/src/pages/trade/conclusion/Conclusion.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import StockExecution, { IStockExecutionItem } from '@recoil/stockExecution/index';
 import './conclusion.scss';
+import Ticks from './Ticks';
+import Days from './Days';
 
 export enum TAB {
 	TICK = '체결',
@@ -31,6 +33,18 @@ const translateTimestampFormat = (timestamp: number): string => {
 const Conclusion = ({ previousClose }: Props) => {
 	const [tab, setTab] = useState(TAB.TICK);
 	const stockExecutionState = useRecoilValue(StockExecution);
+
+	const getCurrentTab = () => {
+		switch (tab) {
+			case TAB.TICK:
+				return <Ticks key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
+			case TAB.DAY:
+				return <Days key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
+			default:
+				return <Ticks key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
+		}
+	};
+
 	return (
 		<div className="conclusion-container">
 			<div className="conclusion-title">
@@ -49,34 +63,7 @@ const Conclusion = ({ previousClose }: Props) => {
 					일별
 				</button>
 			</div>
-			<header className="conclusion-header">
-				<div className="conclusion-timestamp">체결시간</div>
-				<div className="conclusion-single-price">체결가격(원)</div>
-				<div className="conclusion-volume">체결량(주)</div>
-				<div className="conclusion-total-price">체결금액(원)</div>
-			</header>
-			<div className="conclusion-content">
-				{stockExecutionState.length === 0 ? (
-					<p className="conclusion-notice-no-data">체결 정보가 없습니다.</p>
-				) : (
-					stockExecutionState.map((log: IStockExecutionItem) => {
-						const [day, time] = translateTimestampFormat(log.timestamp).split(' ');
-						return (
-							<div className="conclusion-row" key={log.id}>
-								<div className="conclusion-timestamp">
-									<span className="timestamp-day">{day}</span>
-									<span className="timestamp-time">{time}</span>
-								</div>
-								<div className={`conclusion-single-price ${colorPicker(previousClose, log.price)}`}>
-									{log.price.toLocaleString('ko-kr')}
-								</div>
-								<div className="conclusion-volume">{log.amount.toLocaleString('ko-kr')}</div>
-								<div className="conclusion-total-price">{log.volume.toLocaleString('ko-kr')}</div>
-							</div>
-						);
-					})
-				)}
-			</div>
+			{getCurrentTab()}
 		</div>
 	);
 };

--- a/front/src/pages/trade/conclusion/Days.tsx
+++ b/front/src/pages/trade/conclusion/Days.tsx
@@ -1,0 +1,59 @@
+import { IStockExecutionItem } from '@src/recoil/stockExecution';
+import React from 'react';
+
+interface Props {
+	stockExecutionState: IStockExecutionItem[];
+	previousClose: number;
+}
+
+const translateTimestampFormat = (timestamp: number): string => {
+	const stamp = new Date(timestamp);
+	const month = `00${stamp.getMonth() + 1}`.slice(-2);
+	const day = `00${stamp.getDate()}`.slice(-2);
+
+	return `${month}.${day}`;
+};
+
+const colorPicker = (prev: number, current: number): string => {
+	if (prev > current) return 'down';
+	if (prev < current) return 'up';
+	return '';
+};
+
+const Ticks = (props: Props) => {
+	const { stockExecutionState, previousClose } = props;
+	return (
+		<>
+			<header className="conclusion-header">
+				<div className="conclusion-timestamp">일자</div>
+				<div className="conclusion-single-price">종가(원)</div>
+				<div className="conclusion-total-price">전일대비(%)</div>
+				<div className="conclusion-volume">체결량(주)</div>
+			</header>
+			<div className="conclusion-content">
+				{stockExecutionState.length === 0 ? (
+					<p className="conclusion-notice-no-data">체결 정보가 없습니다.</p>
+				) : (
+					stockExecutionState.map((log: IStockExecutionItem) => {
+						const [day, time] = translateTimestampFormat(log.timestamp).split(' ');
+						return (
+							<div className="conclusion-row" key={log.id}>
+								<div className="conclusion-timestamp">
+									<span className="timestamp-day">{day}</span>
+									<span className="timestamp-time">{time}</span>
+								</div>
+								<div className={`conclusion-single-price ${colorPicker(previousClose, log.price)}`}>
+									{log.price.toLocaleString('ko-kr')}
+								</div>
+								<div className="conclusion-volume">{log.amount.toLocaleString('ko-kr')}</div>
+								<div className="conclusion-total-price">{log.volume.toLocaleString('ko-kr')}</div>
+							</div>
+						);
+					})
+				)}
+			</div>
+		</>
+	);
+};
+
+export default Ticks;

--- a/front/src/pages/trade/conclusion/Days.tsx
+++ b/front/src/pages/trade/conclusion/Days.tsx
@@ -1,5 +1,7 @@
 import { IStockExecutionItem } from '@src/recoil/stockExecution';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
+import StockList, { IStockListItem } from '@recoil/stockList/index';
 
 interface Props {
 	stockExecutionState: IStockExecutionItem[];
@@ -22,6 +24,8 @@ const colorPicker = (prev: number, current: number): string => {
 
 const Ticks = (props: Props) => {
 	const { stockExecutionState, previousClose } = props;
+	const stockListState = useRecoilValue(StockList);
+
 	return (
 		<>
 			<header className="conclusion-header">

--- a/front/src/pages/trade/conclusion/Ticks.tsx
+++ b/front/src/pages/trade/conclusion/Ticks.tsx
@@ -1,0 +1,61 @@
+import { IStockExecutionItem } from '@src/recoil/stockExecution';
+import React from 'react';
+
+interface Props {
+	stockExecutionState: IStockExecutionItem[];
+	previousClose: number;
+}
+
+const translateTimestampFormat = (timestamp: number): string => {
+	const stamp = new Date(timestamp);
+	const month = `00${stamp.getMonth() + 1}`.slice(-2);
+	const day = `00${stamp.getDate()}`.slice(-2);
+	const hour = `00${stamp.getHours()}`.slice(-2);
+	const minute = `00${stamp.getMinutes()}`.slice(-2);
+
+	return `${month}.${day} ${hour}:${minute}`;
+};
+
+const colorPicker = (prev: number, current: number): string => {
+	if (prev > current) return 'down';
+	if (prev < current) return 'up';
+	return '';
+};
+
+const Ticks = (props: Props) => {
+	const { stockExecutionState, previousClose } = props;
+	return (
+		<>
+			<header className="conclusion-header">
+				<div className="conclusion-timestamp">체결시간</div>
+				<div className="conclusion-single-price">체결가격(원)</div>
+				<div className="conclusion-volume">체결량(주)</div>
+				<div className="conclusion-total-price">체결금액(원)</div>
+			</header>
+			<div className="conclusion-content">
+				{stockExecutionState.length === 0 ? (
+					<p className="conclusion-notice-no-data">체결 정보가 없습니다.</p>
+				) : (
+					stockExecutionState.map((log: IStockExecutionItem) => {
+						const [day, time] = translateTimestampFormat(log.timestamp).split(' ');
+						return (
+							<div className="conclusion-row" key={log.id}>
+								<div className="conclusion-timestamp">
+									<span className="timestamp-day">{day}</span>
+									<span className="timestamp-time">{time}</span>
+								</div>
+								<div className={`conclusion-single-price ${colorPicker(previousClose, log.price)}`}>
+									{log.price.toLocaleString('ko-kr')}
+								</div>
+								<div className="conclusion-volume">{log.amount.toLocaleString('ko-kr')}</div>
+								<div className="conclusion-total-price">{log.volume.toLocaleString('ko-kr')}</div>
+							</div>
+						);
+					})
+				)}
+			</div>
+		</>
+	);
+};
+
+export default Ticks;

--- a/front/src/pages/trade/conclusion/conclusion.scss
+++ b/front/src/pages/trade/conclusion/conclusion.scss
@@ -5,6 +5,7 @@
 	width: 100%;
 	height: 100%;
 	border-radius: $cardBorderRadius;
+	border-radius: 6px;
 }
 .conclusion-title {
 	display: flex;

--- a/front/src/pages/trade/conclusion/conclusion.scss
+++ b/front/src/pages/trade/conclusion/conclusion.scss
@@ -5,7 +5,6 @@
 	width: 100%;
 	height: 100%;
 	border-radius: $cardBorderRadius;
-	border-radius: 6px;
 }
 .conclusion-title {
 	display: flex;


### PR DESCRIPTION
1. Auctioneer가 체결 시에 매수자/매도자의 보유 종목을 정상적으로 반영 해주지않던 현상을 수정합니다.
2. 쿼리들의 베타적 잠금을 완화합니다.
3. Auctioneer의 보유 종목 조회 쿼리에 대해 낙관적 잠금을 설정합니다.
4. Auctioneer의 체결 방식을 API 요청이 올때마다 체결을 처리하는 것이 아닌 종목별 1개의 체결 시스템이 실행되도록 변경합니다.