### PR TITLE
스케줄러로 생성된 차트 데이터 전송

### DIFF
--- a/auctioneer/src/repositories/OrderRepository.ts
+++ b/auctioneer/src/repositories/OrderRepository.ts
@@ -29,7 +29,7 @@ export default class OrderRepository extends Repository<Order> {
 
 	public async updateOrder(order: Order, amount: number): Promise<void> {
 		this.createQueryBuilder()
-			.setLock('optimistic', 0)
+			.setLock('optimistic', order.version)
 			.update(Order)
 			.set({
 				amount: () => `amount - ${amount}`,

--- a/back/src/api/stock/log.ts
+++ b/back/src/api/stock/log.ts
@@ -30,5 +30,19 @@ export default (): express.Router => {
 		}
 	});
 
+	router.get('/log/daily', async (req: Request, res: Response, next: NextFunction) => {
+		const { code } = req.query;
+		if (!code) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
+
+		try {
+			const stockService = new StockService();
+			const dailyLogs = await stockService.getDailyLogs(code as string);
+
+			res.status(200).json({ code, logs: dailyLogs });
+		} catch (error) {
+			next(error);
+		}
+	});
+
 	return router;
 };

--- a/back/src/api/stock/stock.ts
+++ b/back/src/api/stock/stock.ts
@@ -1,12 +1,12 @@
 import OrderService from '@services/OrderService';
 import StockService from '@services/StockService';
-import express, { Request, Response } from 'express';
+import express, { NextFunction, Request, Response } from 'express';
 import Emitter from '../../helper/eventEmitter';
 
 export default (): express.Router => {
 	const router = express.Router();
+
 	router.post('/conclusion', async (req: Request, res: Response) => {
-		res.end();
 		const msg = req.body;
 		const orderServiceInstance = new OrderService();
 		const { code: stockCode, stockId } = msg.match;
@@ -14,16 +14,106 @@ export default (): express.Router => {
 		const { bidUser, askUser, ...matchMessage } = msg.match;
 		const broadcastMessage = { ...msg, match: matchMessage };
 
+		res.end();
+
 		Emitter.emit('broadcast', { stockCode, msg: broadcastMessage });
 		Emitter.emit('notice', bidUser, { userType: 'bid', stockCode });
 		Emitter.emit('notice', askUser, { userType: 'ask', stockCode });
 	});
 
+	router.post('/chart/new', async (req: Request, res: Response) => {
+		const { charts } = req.body;
+		const stockChartJson = {};
+		charts.forEach((stock) => {
+			stockChartJson[stock.code] = stock;
+		});
+
+		res.end();
+
+		Emitter.emit('chart', stockChartJson);
+	});
+
 	router.get('/prices', async (req: Request, res: Response) => {
 		const stockService = new StockService();
 		const stockList = await stockService.getPriceStockAll();
+
 		res.status(200).json({ stocks: stockList });
 	});
 
 	return router;
 };
+
+/*
+[
+  {
+    code: 'HNX',
+    type: 1,
+    priceBefore: 0,
+    priceStart: 115800,
+    priceEnd: 115700,
+    priceHigh: 117000,
+    priceLow: 115700,
+    amount: 58,
+    volume: 6729600,
+    createdAt: 1637808900043,
+    _id: '619efb04e74560355faed6cb',
+    __v: 0
+  },
+  {
+    code: 'CRG',
+    type: 1,
+    priceBefore: 0,
+    priceStart: 1002000,
+    priceEnd: 995800,
+    priceHigh: 1002000,
+    priceLow: 993200,
+    amount: 42,
+    volume: 41907700,
+    createdAt: 1637808900044,
+    _id: '619efb04e74560355faed6cc',
+    __v: 0
+  },
+  {
+    code: 'JK',
+    type: 1,
+    priceBefore: 0,
+    priceStart: 696800,
+    priceEnd: 697300,
+    priceHigh: 704500,
+    priceLow: 696800,
+    amount: 40,
+    volume: 27949800,
+    createdAt: 1637808900045,
+    _id: '619efb04e74560355faed6cd',
+    __v: 0
+  },
+  {
+    code: 'IVY',
+    type: 1,
+    priceBefore: 0,
+    priceStart: 8403000,
+    priceEnd: 8359000,
+    priceHigh: 8475000,
+    priceLow: 8359000,
+    amount: 69,
+    volume: 579660000,
+    createdAt: 1637808900045,
+    _id: '619efb04e74560355faed6ce',
+    __v: 0
+  },
+  {
+    code: 'TEST',
+    type: 1,
+    priceBefore: 0,
+    priceStart: 0,
+    priceEnd: 0,
+    priceHigh: 0,
+    priceLow: 0,
+    amount: 0,
+    volume: 0,
+    createdAt: 1637808900045,
+    _id: '619efb04e74560355faed6cf',
+    __v: 0
+  }
+] {
+*/

--- a/back/src/services/StockService.ts
+++ b/back/src/services/StockService.ts
@@ -1,8 +1,8 @@
 /* eslint-disable class-methods-use-this */
-import { EntityManager, getCustomRepository, getConnection, createConnection } from 'typeorm';
+import { EntityManager, getCustomRepository, getConnection } from 'typeorm';
 import { Stock, ChartLog, TransactionLog, ITransactionLog } from '@models/index';
 import { StockRepository } from '@repositories/index';
-import { CommonError, CommonErrorMessage, ParamError, ParamErrorMessage, StockError, StockErrorMessage } from 'errors/index';
+import { CommonError, CommonErrorMessage, StockError, StockErrorMessage } from 'errors/index';
 import IChartLog, { CHARTTYPE_VALUE } from '@interfaces/IChartLog';
 
 export default class StockService {
@@ -104,5 +104,13 @@ export default class StockService {
 		const stockRepository = connection.getCustomRepository(StockRepository);
 		const stockPrices = await stockRepository.readPriceStocks();
 		return stockPrices;
+	}
+
+	public async getDailyLogs(code: string): Promise<IChartLog[]> {
+		const dailyLogs = await ChartLog.find({ stockCode: code }, { _id: 1, priceEnd: 1, amount: 1, createdAt: 1 })
+			.sort({ createdAt: -1 })
+			.limit(50);
+
+		return dailyLogs;
 	}
 }

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -233,6 +233,16 @@ const startSocket = ({ setSocket, setStockList, setStockExecution, setAskOrders,
 				setStockExecution(dataToExecutionForm(data.conclusions));
 				break;
 			}
+			case 'chart': {
+				const { type: chartType } = data;
+				if (chartType === 1) {
+					// 1분봉 차트 생성
+				}
+				if (chartType === 1440) {
+					// 일봉 차트 생성
+				}
+				break;
+			}
 			case 'notice': {
 				if (data.userType === 'bid')
 					toast.success(

--- a/front/src/pages/trade/Trade.tsx
+++ b/front/src/pages/trade/Trade.tsx
@@ -109,7 +109,7 @@ const Trade = () => {
 						</section>
 					</section>
 					<section className="trade-conclusion">
-						<Conclusion previousClose={stockState.previousClose} />
+						<Conclusion previousClose={stockState.previousClose} stockCode={stockCode} />
 					</section>
 				</section>
 			</section>

--- a/front/src/pages/trade/chart/Chart.tsx
+++ b/front/src/pages/trade/chart/Chart.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React, { useState, useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
 import useChartData from './useChartData';
 import { ICrossLine } from './common';
 
@@ -9,7 +10,6 @@ import VolumeGraph from './VolumeGraph';
 import PeriodLegend from './PeriodLegend';
 
 import './Chart.scss';
-import { Link } from 'react-router-dom';
 
 const DEFAULT_START_INDEX = 0;
 const DEFAULT_END_INDEX = 60;
@@ -40,7 +40,6 @@ const Chart = ({ stockCode, stockType }: { stockCode: string; stockType: number 
 	const [offset, setOffset] = useState<number>(-1);
 	const [crossLine, setCrossLine] = useState<ICrossLine>({ event: null, posX: 0, posY: 0 });
 	const [chart, next] = useChartData(stockCode, stockType, offset);
-
 
 	useEffect(() => {
 		const bindedMoveCrossLine = moveCrossLine.bind(undefined, setCrossLine);

--- a/front/src/pages/trade/conclusion/Conclusion.tsx
+++ b/front/src/pages/trade/conclusion/Conclusion.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import StockExecution, { IStockExecutionItem } from '@recoil/stockExecution/index';
+import StockExecution from '@recoil/stockExecution/index';
 import './conclusion.scss';
 import Ticks from './Ticks';
 import Days from './Days';

--- a/front/src/pages/trade/conclusion/Conclusion.tsx
+++ b/front/src/pages/trade/conclusion/Conclusion.tsx
@@ -11,26 +11,11 @@ export enum TAB {
 }
 
 interface Props {
+	stockCode: string;
 	previousClose: number;
 }
 
-const colorPicker = (prev: number, current: number): string => {
-	if (prev > current) return 'down';
-	if (prev < current) return 'up';
-	return '';
-};
-
-const translateTimestampFormat = (timestamp: number): string => {
-	const stamp = new Date(timestamp);
-	const month = `00${stamp.getMonth() + 1}`.slice(-2);
-	const day = `00${stamp.getDate()}`.slice(-2);
-	const hour = `00${stamp.getHours()}`.slice(-2);
-	const minute = `00${stamp.getMinutes()}`.slice(-2);
-
-	return `${month}.${day} ${hour}:${minute}`;
-};
-
-const Conclusion = ({ previousClose }: Props) => {
+const Conclusion = ({ previousClose, stockCode }: Props) => {
 	const [tab, setTab] = useState(TAB.TICK);
 	const stockExecutionState = useRecoilValue(StockExecution);
 
@@ -39,7 +24,14 @@ const Conclusion = ({ previousClose }: Props) => {
 			case TAB.TICK:
 				return <Ticks key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
 			case TAB.DAY:
-				return <Days key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
+				return (
+					<Days
+						key={tab}
+						stockCode={stockCode}
+						stockExecutionState={stockExecutionState}
+						previousClose={previousClose}
+					/>
+				);
 			default:
 				return <Ticks key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
 		}

--- a/front/src/pages/trade/conclusion/Days.tsx
+++ b/front/src/pages/trade/conclusion/Days.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from 'recoil';
 import StockList, { IStockListItem } from '@recoil/stockList/index';
 
 interface Props {
+	stockCode: string;
 	stockExecutionState: IStockExecutionItem[];
 	previousClose: number;
 }
@@ -22,9 +23,9 @@ const colorPicker = (prev: number, current: number): string => {
 	return '';
 };
 
-const Ticks = (props: Props) => {
-	const { stockExecutionState, previousClose } = props;
+const Ticks = ({ stockCode, stockExecutionState, previousClose }: Props) => {
 	const stockListState = useRecoilValue(StockList);
+	const targetStock = stockListState.find((stock) => stock.code === stockCode)?.charts.find((chart) => chart.type === 1440);
 
 	return (
 		<>

--- a/front/src/pages/trade/conclusion/Days.tsx
+++ b/front/src/pages/trade/conclusion/Days.tsx
@@ -1,13 +1,12 @@
 import { IStockExecutionItem } from '@src/recoil/stockExecution';
 import React from 'react';
-import { useRecoilValue } from 'recoil';
-import StockList, { IStockListItem } from '@recoil/stockList/index';
 
 interface Props {
 	stockCode: string;
 	stockExecutionState: IStockExecutionItem[];
 	previousClose: number;
 }
+const fetchDailyLog = () => {};
 
 const translateTimestampFormat = (timestamp: number): string => {
 	const stamp = new Date(timestamp);
@@ -24,9 +23,6 @@ const colorPicker = (prev: number, current: number): string => {
 };
 
 const Ticks = ({ stockCode, stockExecutionState, previousClose }: Props) => {
-	const stockListState = useRecoilValue(StockList);
-	const targetStock = stockListState.find((stock) => stock.code === stockCode)?.charts.find((chart) => chart.type === 1440);
-
 	return (
 		<>
 			<header className="conclusion-header">


### PR DESCRIPTION
1. Auctioneer에서 일봉, 1분봉에 해당하는 차트 데이터를 생성합니다
2. 생성된 데이터를 backend의 API를 호출하여 전달합니다
3. backend는 전달 받은 차트 데이터 리스트를 오브젝트에 종목코드를 키값으로 갖도록 가공하여 소켓에게 전달합니다
4. 소켓에 접속한 유저들을 조회하여 해당 유저가 보고 있는 종목에 대한 차트 데이터를 전송합니다