### PR TITLE
Math.floor로 인한 캔들 width 오류 수정

### DIFF
--- a/front/src/pages/trade/chart/CandleGraph.tsx
+++ b/front/src/pages/trade/chart/CandleGraph.tsx
@@ -97,7 +97,7 @@ const CandleGraph = ({ chartData, crossLine }: IProps) => {
 		if (!ctx) return;
 
 		const NUM_OF_CANDLES = chartData.length;
-		const candleWidth = Math.floor((CANVAS_WIDTH - (NUM_OF_CANDLES + 1) * CANDLE_GAP) / NUM_OF_CANDLES);
+		const candleWidth = (CANVAS_WIDTH - (NUM_OF_CANDLES + 1) * CANDLE_GAP) / NUM_OF_CANDLES;
 		const TAIL_WIDTH = 1;
 
 		const maxPrice = getMaxValue(chartData, 'amount', 'priceHigh', RATIO_MAX);


### PR DESCRIPTION
- Math.floor 함수로 인해 소수점 이하 값이 절사되어 캔들의 width가 잘못 표기되던 오류를 수정하였습니다.