### PR TITLE
일별 종목 정보 렌더링, 로그아웃 로직 추가 구현

### DIFF
--- a/back/src/api/auth/signout.ts
+++ b/back/src/api/auth/signout.ts
@@ -1,15 +1,19 @@
-import express, { NextFunction, Request, Response } from 'express';
-import config from '@config/index';
+import { AuthError, AuthErrorMessage } from 'errors';
 import UserService from '@services/UserService';
-import { AuthError, AuthErrorMessage } from '@errors/index';
+import express, { NextFunction, Request, Response } from 'express';
+import eventEmitter from '@helper/eventEmitter';
 
 export default (): express.Router => {
 	const router = express.Router();
 
 	router.post('/signout', (req: Request, res: Response, next: NextFunction) => {
 		try {
-			res.clearCookie(config.sessionCookieId);
+			const { alarmToken } = req.cookies;
+			res.clearCookie('connect.sid');
+			res.clearCookie('alarmToken');
 			req.session.destroy(() => res.status(200).json({}));
+
+			eventEmitter.emit('logout', alarmToken);
 		} catch (error) {
 			next(error);
 		}

--- a/back/src/api/stock/stock.ts
+++ b/back/src/api/stock/stock.ts
@@ -1,6 +1,6 @@
 import OrderService from '@services/OrderService';
 import StockService from '@services/StockService';
-import express, { NextFunction, Request, Response } from 'express';
+import express, { Request, Response } from 'express';
 import Emitter from '../../helper/eventEmitter';
 
 export default (): express.Router => {
@@ -42,78 +42,3 @@ export default (): express.Router => {
 
 	return router;
 };
-
-/*
-[
-  {
-    code: 'HNX',
-    type: 1,
-    priceBefore: 0,
-    priceStart: 115800,
-    priceEnd: 115700,
-    priceHigh: 117000,
-    priceLow: 115700,
-    amount: 58,
-    volume: 6729600,
-    createdAt: 1637808900043,
-    _id: '619efb04e74560355faed6cb',
-    __v: 0
-  },
-  {
-    code: 'CRG',
-    type: 1,
-    priceBefore: 0,
-    priceStart: 1002000,
-    priceEnd: 995800,
-    priceHigh: 1002000,
-    priceLow: 993200,
-    amount: 42,
-    volume: 41907700,
-    createdAt: 1637808900044,
-    _id: '619efb04e74560355faed6cc',
-    __v: 0
-  },
-  {
-    code: 'JK',
-    type: 1,
-    priceBefore: 0,
-    priceStart: 696800,
-    priceEnd: 697300,
-    priceHigh: 704500,
-    priceLow: 696800,
-    amount: 40,
-    volume: 27949800,
-    createdAt: 1637808900045,
-    _id: '619efb04e74560355faed6cd',
-    __v: 0
-  },
-  {
-    code: 'IVY',
-    type: 1,
-    priceBefore: 0,
-    priceStart: 8403000,
-    priceEnd: 8359000,
-    priceHigh: 8475000,
-    priceLow: 8359000,
-    amount: 69,
-    volume: 579660000,
-    createdAt: 1637808900045,
-    _id: '619efb04e74560355faed6ce',
-    __v: 0
-  },
-  {
-    code: 'TEST',
-    type: 1,
-    priceBefore: 0,
-    priceStart: 0,
-    priceEnd: 0,
-    priceHigh: 0,
-    priceLow: 0,
-    amount: 0,
-    volume: 0,
-    createdAt: 1637808900045,
-    _id: '619efb04e74560355faed6cf',
-    __v: 0
-  }
-] {
-*/

--- a/back/src/loaders/socket.ts
+++ b/back/src/loaders/socket.ts
@@ -34,14 +34,23 @@ const disconnectUser = (client) => {
 	socketClientMap.delete(client);
 };
 
+const logoutUserHandler = (alarmToken) => {
+	const logoutUser = loginUserMap.get(alarmToken);
+	const logoutSocket = socketAlarmMap.get(logoutUser);
+
+	loginUserMap.delete(alarmToken);
+	socketAlarmMap.delete(logoutUser);
+	socketClientMap.set(logoutSocket, { ...socketClientMap.get(logoutSocket), alarmToken: '' });
+};
+
 const broadcast = ({ stockCode, msg }) => {
 	socketClientMap.forEach(({ target: targetStockCode }, client) => {
 		if (targetStockCode === stockCode) {
 			// 모든 데이터 전송, 현재가, 호가, 차트 등...
-			client.send(translateResponseFormat('updateTarget', msg));
+			client?.send(translateResponseFormat('updateTarget', msg));
 		} else {
 			// msg 오브젝트의 데이터에서 aside 바에 필요한 데이터만 골라서 전송
-			client.send(translateResponseFormat('updateStock', msg.match));
+			client?.send(translateResponseFormat('updateStock', msg.match));
 		}
 	});
 };
@@ -112,3 +121,5 @@ export default async (app: Application): Promise<void> => {
 		});
 	});
 };
+
+Emitter.on('logout', logoutUserHandler);

--- a/back/src/services/StockService.ts
+++ b/back/src/services/StockService.ts
@@ -107,9 +107,9 @@ export default class StockService {
 	}
 
 	public async getDailyLogs(code: string): Promise<IChartLog[]> {
-		const dailyLogs = await ChartLog.find({ stockCode: code }, { _id: 1, priceEnd: 1, amount: 1, createdAt: 1 })
+		const dailyLogs = await ChartLog.find({ code, type: 1440 }, { _id: 1, code: 1, priceEnd: 1, amount: 1, createdAt: 1 })
 			.sort({ createdAt: -1 })
-			.limit(50);
+			.limit(51);
 
 		return dailyLogs;
 	}

--- a/front/src/pages/trade/conclusion/Conclusion.tsx
+++ b/front/src/pages/trade/conclusion/Conclusion.tsx
@@ -24,14 +24,7 @@ const Conclusion = ({ previousClose, stockCode }: Props) => {
 			case TAB.TICK:
 				return <Ticks key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
 			case TAB.DAY:
-				return (
-					<Days
-						key={tab}
-						stockCode={stockCode}
-						stockExecutionState={stockExecutionState}
-						previousClose={previousClose}
-					/>
-				);
+				return <Days key={tab} stockCode={stockCode} />;
 			default:
 				return <Ticks key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
 		}

--- a/front/src/pages/trade/conclusion/conclusion.scss
+++ b/front/src/pages/trade/conclusion/conclusion.scss
@@ -92,6 +92,14 @@
 		margin-left: 6px;
 	}
 
+	& > div:first-child {
+		margin-left: 10px;
+	}
+
+	& > div:last-child {
+		margin-right: 10px;
+	}
+
 	.dark-theme & {
 		border-top: 1px solid $darkModeBorderColor;
 		border-bottom: 1px solid $darkModeBorderColor;
@@ -120,7 +128,6 @@
 .conclusion-total-price {
 	flex: 10;
 	text-align: right;
-	padding: 0 10px;
 }
 .conclusion-volume {
 	flex: 10;
@@ -136,8 +143,7 @@
 	align-items: center;
 	height: 34px;
 	font-size: 14px;
-	padding: 5px 0;
-	margin-left: 6px;
+	padding: 5px 10px;
 	cursor: pointer;
 
 	& + & {

--- a/front/src/recoil/stockDailyLog/atom.ts
+++ b/front/src/recoil/stockDailyLog/atom.ts
@@ -1,0 +1,15 @@
+import { atom } from 'recoil';
+
+export interface IDailyLog {
+	_id: string;
+	priceEnd: number;
+	amount: number;
+	createdAt: number;
+}
+
+const dailyLogAtom = atom<IDailyLog[]>({
+	key: 'dailyLogAtom',
+	default: [],
+});
+
+export default dailyLogAtom;

--- a/front/src/recoil/stockDailyLog/index.ts
+++ b/front/src/recoil/stockDailyLog/index.ts
@@ -1,0 +1,5 @@
+import atom from './atom';
+import type { IDailyLog } from './atom';
+
+export { IDailyLog };
+export default atom;


### PR DESCRIPTION
1. 종목 상세 컴포넌트 하단의 일별 탭을 렌더링합니다
    - 유저가 확인 중인 종목의 코드를 API로 요청하여 일별 데이터를 가져옵니다.
2. 로그아웃 시 알람토큰 제거 로직 구현
    - 쿠키에서 알람 토큰을 제거합니다
    - 소켓에게 알려 유저에게 등록된 알람토큰 정보를 모두 제거합니다.