### PR TITLE
배포 환경에서 https 모듈 사용  및 SSL 적용

### DIFF
--- a/auctioneer/src/app.ts
+++ b/auctioneer/src/app.ts
@@ -1,11 +1,39 @@
 import express from 'express';
+import fs from 'fs';
 import _http from 'http';
+import _https from 'https';
 
 import Logger from '@loaders/logger';
 import loaders from '@loaders/index';
 import config from '@config/index';
 
-async function startServer() {
+async function startHttpsServer() {
+	const app = express();
+	const https = _https.createServer(
+		{
+			ca: fs.readFileSync('/etc/ssl/ca_bundle.crt'),
+			key: fs.readFileSync('/etc/ssl/private.key'),
+			cert: fs.readFileSync('/etc/ssl/certificate.crt'),
+		},
+		app,
+	);
+	await loaders({ expressApp: app });
+
+	https
+		.listen(config.port, () => {
+			Logger.info(`
+    	################################################
+    	🛡️  Server listening on port: ${config.port} 🛡️
+    	################################################
+      `);
+		})
+		.on('error', (err) => {
+			Logger.error(err);
+			process.exit(1);
+		});
+}
+
+async function startHttpServer() {
 	const app = express();
 	const http = _http.createServer(app);
 	await loaders({ expressApp: app });
@@ -22,4 +50,5 @@ async function startServer() {
 	});
 }
 
-startServer();
+if (process.env.NODE_ENV === 'production') startHttpsServer();
+else startHttpServer();

--- a/back/src/app.ts
+++ b/back/src/app.ts
@@ -1,11 +1,39 @@
 import express from 'express';
+import fs from 'fs';
 import _http from 'http';
+import _https from 'https';
 
 import Logger from '@loaders/logger';
 import loaders from '@loaders/index';
 import config from '@config/index';
 
-async function startServer() {
+async function startHttpsServer() {
+	const app = express();
+	const https = _https.createServer(
+		{
+			ca: fs.readFileSync('/etc/ssl/ca_bundle.crt'),
+			key: fs.readFileSync('/etc/ssl/private.key'),
+			cert: fs.readFileSync('/etc/ssl/certificate.crt'),
+		},
+		app,
+	);
+	await loaders({ expressApp: app });
+
+	https
+		.listen(config.port, () => {
+			Logger.info(`
+    	################################################
+    	🛡️  Server listening on port: ${config.port} 🛡️
+    	################################################
+      `);
+		})
+		.on('error', (err) => {
+			Logger.error(err);
+			process.exit(1);
+		});
+}
+
+async function startHttpServer() {
 	const app = express();
 	const http = _http.createServer(app);
 	await loaders({ expressApp: app });
@@ -22,4 +50,5 @@ async function startServer() {
 	});
 }
 
-startServer();
+if (process.env.NODE_ENV === 'production') startHttpsServer();
+else startHttpServer();


### PR DESCRIPTION
배포 환경에서는 https 모듈을 사용하고 SSL을 적용하도록 수정합니다.
인증서는 기존 도메인인 boostock.kro.kr로 발급받았습니다.

개발환경에서는 http 설정을 그대로 유지합니다.
코드 프리징을 해야하니 일단 드래프트로 걸어놓고, 데모를 마치고 반영하겠습니다 ^^
