### PR TITLE
입출금 페이지 다크모드 버그 수정 및 기타 스타일 수정

### DIFF
--- a/front/src/pages/balance/Balance.scss
+++ b/front/src/pages/balance/Balance.scss
@@ -7,6 +7,8 @@
 	align-items: center;
 	justify-content: flex-start;
 
+	width: 100%;
+	height: 100vh;
 	padding: 96px 32px 32px 32px;
 	box-sizing: border-box;
 }
@@ -46,6 +48,7 @@
 	display: block;
 	max-height: 60vh;
 	overflow-y: scroll;
+	padding-left: 6px;
 	@include scrollBarStyle();
 }
 

--- a/front/src/pages/balance/Balance.tsx
+++ b/front/src/pages/balance/Balance.tsx
@@ -131,7 +131,15 @@ const Balance = () => {
 							<th className="my__legend-number">승인시간</th>
 						</tr>
 					</thead>
-					<tbody className="balance-items">{histories.map((history: IHistory) => getHistory(history))}</tbody>
+					<tbody className="balance-items">
+						{histories.length > 0 ? (
+							histories.map((history: IHistory) => getHistory(history))
+						) : (
+							<tr className="my__item">
+								<td className="my__item-center">입출금 내역이 없습니다.</td>
+							</tr>
+						)}
+					</tbody>
 				</table>
 			</div>
 		</div>

--- a/front/src/pages/my/Holds.scss
+++ b/front/src/pages/my/Holds.scss
@@ -2,7 +2,6 @@
 
 .my-holds {
 	width: 100%;
-	height: 60vh;
 
 	@include darkModeCardStyle();
 }
@@ -13,4 +12,5 @@
 	display: block;
 	max-height: 60vh;
 	overflow-y: scroll;
+	padding-left: 6px;
 }

--- a/front/src/pages/my/Holds.tsx
+++ b/front/src/pages/my/Holds.tsx
@@ -47,7 +47,15 @@ const Holds = (props: HoldsProps) => {
 					<th className="my__legend-number">평가손익</th>
 				</tr>
 			</thead>
-			<tbody className="hold-items">{holds.map((hold: IHold) => getHold(hold))}</tbody>
+			<tbody className="hold-items">
+				{holds.length > 0 ? (
+					holds.map((hold: IHold) => getHold(hold))
+				) : (
+					<tr className="my__item">
+						<td className="my__item-center">보유 종목이 없습니다.</td>
+					</tr>
+				)}
+			</tbody>
 		</table>
 	);
 };

--- a/front/src/pages/my/My.scss
+++ b/front/src/pages/my/My.scss
@@ -73,7 +73,7 @@
 .my__legend {
 	width: 100%;
 	height: 32px;
-	padding: 0px 16px 0px 10px;
+	padding: 0px 16px;
 	box-sizing: border-box;
 	font-size: 12px;
 	font-weight: 700;
@@ -120,7 +120,6 @@
 	height: 48px;
 	padding: 0px 10px;
 	box-sizing: border-box;
-	border-bottom: 1px solid $borderColor;
 
 	display: flex;
 	align-items: center;
@@ -129,8 +128,12 @@
 
 	font-size: 12px;
 
-	.dark-theme & {
-		border-bottom: 1px solid $darkModeBorderColor;
+	& + & {
+		border-top: 1px solid $borderColor;
+	}
+
+	.dark-theme & + &{
+		border-top: 1px solid $darkModeBorderColor;
 	}
 
 	& > * {

--- a/front/src/pages/my/Orders.scss
+++ b/front/src/pages/my/Orders.scss
@@ -2,7 +2,6 @@
 
 .my-orders {
 	width: 100%;
-	height: 60vh;
 
 	@include darkModeCardStyle();
 }
@@ -13,6 +12,7 @@
 	display: block;
 	max-height: 60vh;
 	overflow-y: scroll;
+	padding-left: 6px;
 }
 
 .cancel-order-btn {

--- a/front/src/pages/my/Orders.tsx
+++ b/front/src/pages/my/Orders.tsx
@@ -121,7 +121,15 @@ const Orders = () => {
 					<th className="my__legend-center">&nbsp;</th>
 				</tr>
 			</thead>
-			<tbody className="my-order-items">{orders.map((order: IOrder) => getOrder(order))}</tbody>
+			<tbody className="my-order-items">
+				{orders.length > 0 ? (
+					orders.map((order: IOrder) => getOrder(order))
+				) : (
+					<tr className="my__item">
+						<td className="my__item-center">주문 내역이 없습니다.</td>
+					</tr>
+				)}
+			</tbody>
 		</table>
 	);
 };

--- a/front/src/pages/my/Transactions.scss
+++ b/front/src/pages/my/Transactions.scss
@@ -2,7 +2,6 @@
 
 .my-transactions {
 	width: 100%;
-	height: 60vh;
 
 	@include darkModeCardStyle();
 }
@@ -13,4 +12,5 @@
 	display: block;
 	max-height: 60vh;
 	overflow-y: scroll;
+	padding-left: 6px;
 }

--- a/front/src/pages/my/Transactions.tsx
+++ b/front/src/pages/my/Transactions.tsx
@@ -92,7 +92,13 @@ const Transactions = () => {
 				</tr>
 			</thead>
 			<tbody className="transaction-items">
-				{transactions.map((transaction: ITransaction) => getTransaction(transaction))}
+				{transactions.length > 0 ? (
+					transactions.map((transaction: ITransaction) => getTransaction(transaction))
+				) : (
+					<tr className="my__item">
+						<td className="my__item-center">거래 내역이 없습니다.</td>
+					</tr>
+				)}
 			</tbody>
 		</table>
 	);


### PR DESCRIPTION
- 아래와 같이 입출금 내역이 짧은 경우 다크모드에서 백그라운드가 제대로 표시되지 않던 버그를 수정하였습니다:

![dark-mode-err](https://user-images.githubusercontent.com/50892653/143540026-c68f3f60-8c1b-4a70-8e72-3ea5356abae8.png)

- 마이페이지/입출금 페이지에 표시되는 각 내역 리스트 아이템들의 마진값과 패딩값을 조정하였습니다.
- 마이페이지/입출금 페이지에 표시되는 내역이 없는 경우 해당 내역이 존재하지 않는다는 텍스트를 출력하게 됩니다.