### PR TITLE
[CI] 환경변수(secrets)를 백엔드 환경변수에서 별도로 분리

### DIFF
--- a/.github/workflows/testBackend.yml
+++ b/.github/workflows/testBackend.yml
@@ -1,7 +1,5 @@
 name: Test Backend
-###################################
-# Required Secret : BACK_ENV, BACK_ORM_CONFIG
-###################################
+
 on:
     pull_request:
         branches: [develop]
@@ -22,21 +20,21 @@ jobs:
 
             - name: Create Environment File
               run: |
-                  echo "${{ secrets.BACK_ENV }}" >> .env.dev
+                  echo "${{ secrets.TEST_ENV }}" >> .env.dev
               working-directory: ./back
 
             - name: Create ORM Config
               uses: jsdaniell/create-json@1.1.2
               with:
                   name: 'ormconfig.json'
-                  json: ${{ secrets.BACK_ORM_CONFIG }}
+                  json: ${{ secrets.TEST_ORM_CONFIG }}
                   dir: 'back/'
 
             - name: Create Session Config
               uses: jsdaniell/create-json@1.1.2
               with:
                   name: 'sessionStoreConfig.json'
-                  json: ${{ secrets.BACK_SESSION_CONFIG }}
+                  json: ${{ secrets.TEST_SESSION_CONFIG }}
                   dir: 'back/'
 
             - name: Run Test


### PR DESCRIPTION
기존 환경변수의 경우, 주소를 로컬로 작성해두었는데
테스트 코드의 경우는 원격 환경에서 진행되어야 하므로 리모트 주소를 입력한 별도의 환경변수로 분리하였습니다.