### PR TITLE
로그인 실패 시, 토스트 메시지가 무한히 발생하는 오류 수정

### DIFF
--- a/front/src/pages/signIn/SignIn.tsx
+++ b/front/src/pages/signIn/SignIn.tsx
@@ -41,6 +41,7 @@ const SignIn = () => {
 				history.push('/');
 				toast.success('성공적으로 로그인 되었습니다.');
 			} else {
+				history.push('/auth/signin');
 				toast.error('로그인에 실패했습니다. 잠시 후 재시도 해주세요.');
 			}
 		});

--- a/front/src/pages/signUp/SignUp.tsx
+++ b/front/src/pages/signUp/SignUp.tsx
@@ -63,10 +63,6 @@ const SignUp = () => {
 		}).then((res: Response) => {
 			if (res.ok) {
 				eventEmitter.emit('registerAlarm', getCookie('alarmToken'));
-
-				// res.json().then(({ alarmToken }) => {
-				// 	eventEmitter.emit('registerAlarm', alarmToken);
-				// });
 				setUserState({ ...userState, isLoggedIn: true });
 				toast.success('성공적으로 회원가입 되었습니다.');
 				history.push('/');


### PR DESCRIPTION
## 관련 이슈
- #181 

## 내용
- 원인 : 깃허브를 거치면서 추가된 콜백 URL 파라메터와 + toast 발동에 의한 리렌더링으로 인해 요청->응답이 반복됨
- 조치 : 백엔드 API 응답이 실패할 경우, 콜백 파라메터를 제거하여 인증 절차를 재진행하도록 수정