### PR TITLE
체결 컴포넌트에 유저가 확인 중인 종목의 체결 내역만 조건 추가, backend의 validator 미들웨어

### DIFF
--- a/back/src/api/auth/github.ts
+++ b/back/src/api/auth/github.ts
@@ -16,6 +16,7 @@ export default (): express.Router => {
 			const alarmToken = generateUUID();
 
 			if (userInfo.userId === undefined) throw new UserError(UserErrorMessage.NOT_EXIST_USER);
+
 			req.session.data = {
 				userId: userInfo.userId,
 				email: userInfo.email,

--- a/back/src/api/auth/signout.ts
+++ b/back/src/api/auth/signout.ts
@@ -2,6 +2,8 @@ import { AuthError, AuthErrorMessage } from 'errors';
 import UserService from '@services/UserService';
 import express, { NextFunction, Request, Response } from 'express';
 import eventEmitter from '@helper/eventEmitter';
+import session from 'express-session';
+import sessionValidator from '@api/middleware/sessionValidator';
 
 export default (): express.Router => {
 	const router = express.Router();
@@ -19,11 +21,11 @@ export default (): express.Router => {
 		}
 	});
 
-	router.delete('/signout', async (req: Request, res: Response, next: NextFunction) => {
+	router.delete('/signout', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			await UserService.destroyAllSession(userId);
+
 			res.status(200).json({});
 		} catch (error) {
 			next(error);

--- a/back/src/api/middleware/logValidator.ts
+++ b/back/src/api/middleware/logValidator.ts
@@ -1,0 +1,26 @@
+import ParamError, { ParamErrorMessage } from '@errors/ParamError';
+import { CHARTTYPE } from '@interfaces/IChartLog';
+import { Request, Response, NextFunction } from 'express';
+
+const logValidator = (req: Request, res: Response, next: NextFunction): void => {
+	try {
+		const { code, start, end } = req.query;
+		const type = Number(req.query.type);
+		if (
+			code === undefined ||
+			type === undefined ||
+			start === undefined ||
+			end === undefined ||
+			!Object.values(CHARTTYPE).find((elem) => elem === type)
+		)
+			throw new ParamError(ParamErrorMessage.INVALID_PARAM);
+		res.locals = { code, start: Number(start), end: Number(end), type };
+		next();
+	} catch (error) {
+		next(error);
+	}
+
+	next();
+};
+
+export default logValidator;

--- a/back/src/api/middleware/orderValidator.ts
+++ b/back/src/api/middleware/orderValidator.ts
@@ -1,7 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import Validator from '@helper/Validator';
 import { ORDERTYPE } from '@models/Order';
-import { ValidationError, ValidationErrorMessage } from 'errors';
+import { ParamError, ParamErrorMessage, ValidationError, ValidationErrorMessage } from 'errors';
+import config from '@config/index';
 
 const QUOTE_DIGIT = 1000;
 const QUOTE_RATE = 1;
@@ -16,13 +17,26 @@ const isCorrectQuote = (price: number) => {
 
 export const orderValidator = (req: Request, res: Response, next: NextFunction): void => {
 	const validator = new Validator();
+	const { stockCode, type, amount, price } = req.body;
 
 	try {
-		validator.init(req.body.stockCode).isString();
-		validator.init(req.body.type).isInObject(ORDERTYPE).isInteger();
-		validator.init(req.body.amount).isInteger().isPositive();
-		validator.init(req.body.price).isInteger().isPositive();
-		isCorrectQuote(req.body.price);
+		validator.init(stockCode).isString();
+		validator.init(type).isInObject(ORDERTYPE).isInteger();
+		validator.init(amount).isInteger().isPositive();
+		validator.init(price).isInteger().isPositive();
+		isCorrectQuote(price);
+
+		if (
+			!stockCode ||
+			!type ||
+			!amount ||
+			!price ||
+			price <= 0 ||
+			price >= config.maxPrice ||
+			amount <= 0 ||
+			amount >= config.maxAmount
+		)
+			throw new ParamError(ParamErrorMessage.INVALID_PARAM);
 
 		next();
 	} catch (err) {
@@ -36,6 +50,25 @@ export const stockIdValidator = (req: Request, res: Response, next: NextFunction
 		validator.init(req.query.stockId).isInteger().isPositive();
 		next();
 	} catch (err) {
+		next(err);
+	}
+};
+
+export const balanceValidator = (req: Request, res: Response, next: NextFunction): void => {
+	try {
+		const { bank, bankAccount, changeValue } = req.body;
+		if (
+			!changeValue ||
+			Number.isNaN(changeValue) ||
+			!bank ||
+			!bankAccount ||
+			changeValue <= 0 ||
+			changeValue >= config.maxTransperMoney
+		)
+			throw new ParamError(ParamErrorMessage.INVALID_PARAM);
+		next();
+	} catch (err) {
+		console.log('validator');
 		next(err);
 	}
 };

--- a/back/src/api/middleware/sessionValidator.ts
+++ b/back/src/api/middleware/sessionValidator.ts
@@ -1,0 +1,15 @@
+import AuthError, { AuthErrorMessage } from '@errors/AuthError';
+import { Request, Response, NextFunction } from 'express';
+
+const sessionValidator = (req: Request, res: Response, next: NextFunction): void => {
+	try {
+		const userId = req.session.data?.userId;
+		if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+		res.locals.userId = userId;
+		next();
+	} catch (error) {
+		next(error);
+	}
+};
+
+export default sessionValidator;

--- a/back/src/api/stock/log.ts
+++ b/back/src/api/stock/log.ts
@@ -1,5 +1,5 @@
 import ParamError, { ParamErrorMessage } from '@errors/ParamError';
-import { CHARTTYPE, CHARTTYPE_VALUE } from '@interfaces/IChartLog';
+import { CHARTTYPE_VALUE } from '@interfaces/IChartLog';
 import StockService from '@services/StockService';
 import express, { NextFunction, Request, Response } from 'express';
 
@@ -8,22 +8,9 @@ export default (): express.Router => {
 
 	router.get('/log', async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const { code, start, end } = req.query;
-			const type = Number(req.query.type);
-			if (
-				code === undefined ||
-				type === undefined ||
-				start === undefined ||
-				end === undefined ||
-				!Object.values(CHARTTYPE).find((elem) => elem === type)
-			)
-				throw new ParamError(ParamErrorMessage.INVALID_PARAM);
-			const log = await StockService.getStockLog(
-				code as string,
-				Number(type) as CHARTTYPE_VALUE,
-				Number(start),
-				Number(end),
-			);
+			const { code, start, end, type } = res.locals;
+			const log = await StockService.getStockLog(code, type as CHARTTYPE_VALUE, start, end);
+
 			res.status(200).json({ log });
 		} catch (error) {
 			next(error);

--- a/back/src/api/user/balance.ts
+++ b/back/src/api/user/balance.ts
@@ -1,15 +1,16 @@
 import express, { NextFunction, Request, Response } from 'express';
-import { AuthError, AuthErrorMessage, ParamError, ParamErrorMessage } from 'errors/index';
+import { ParamError, ParamErrorMessage } from 'errors/index';
 import { UserService } from '@services/index';
 import { IBalanceLog, BALANCETYPE, STATUSTYPE } from '@models/index';
 import config from '@config/index';
+import sessionValidator from '@api/middleware/sessionValidator';
+import { balanceValidator } from '@api/middleware/orderValidator';
 
 export default (): express.Router => {
 	const router = express.Router();
-	router.get('/balance', async (req: Request, res: Response, next: NextFunction) => {
+	router.get('/balance', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const { type, start, end } = req.query;
 			const result = await UserService.getUserById(userId);
 			const { balance } = result;
@@ -20,69 +21,60 @@ export default (): express.Router => {
 		}
 	});
 
-	router.post('/balance/deposit', async (req: Request, res: Response, next: NextFunction) => {
-		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
-			const { bank, bankAccount, changeValue } = req.body;
-			if (
-				!changeValue ||
-				Number.isNaN(changeValue) ||
-				!bank ||
-				!bankAccount ||
-				changeValue <= 0 ||
-				changeValue >= config.maxTransperMoney
-			)
-				throw new ParamError(ParamErrorMessage.INVALID_PARAM);
-			const result = await UserService.updateBalance(userId, changeValue);
-			const { balance } = result;
+	router.post(
+		'/balance/deposit',
+		sessionValidator,
+		balanceValidator,
+		async (req: Request, res: Response, next: NextFunction) => {
+			try {
+				const { userId } = res.locals;
+				const { bank, bankAccount, changeValue } = req.body;
+				const result = await UserService.updateBalance(userId, changeValue);
+				const { balance } = result;
 
-			const newBalanceLog: IBalanceLog = {
-				type: BALANCETYPE.DEPOSIT,
-				volume: changeValue,
-				status: STATUSTYPE.FINISHED,
-				bank,
-				bankAccount,
-				createdAt: new Date().getTime(),
-			};
-			await UserService.pushBalanceLog(userId, newBalanceLog);
-			res.status(200).json({ balance });
-		} catch (error) {
-			next(error);
-		}
-	});
+				const newBalanceLog: IBalanceLog = {
+					type: BALANCETYPE.DEPOSIT,
+					volume: changeValue,
+					status: STATUSTYPE.FINISHED,
+					bank,
+					bankAccount,
+					createdAt: new Date().getTime(),
+				};
+				await UserService.pushBalanceLog(userId, newBalanceLog);
+				res.status(200).json({ balance });
+			} catch (error) {
+				next(error);
+			}
+		},
+	);
 
-	router.post('/balance/withdraw', async (req: Request, res: Response, next: NextFunction) => {
-		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
-			const { bank, bankAccount, changeValue } = req.body;
-			if (
-				!changeValue ||
-				Number.isNaN(changeValue) ||
-				!bank ||
-				!bankAccount ||
-				changeValue <= 0 ||
-				changeValue >= config.maxTransperMoney
-			)
-				throw new ParamError(ParamErrorMessage.INVALID_PARAM);
-			const result = await UserService.updateBalance(userId, changeValue * -1);
-			const { balance } = result;
+	router.post(
+		'/balance/withdraw',
+		sessionValidator,
+		balanceValidator,
+		async (req: Request, res: Response, next: NextFunction) => {
+			try {
+				const { userId } = res.locals;
+				const { bank, bankAccount, changeValue } = req.body;
 
-			const newBalanceLog: IBalanceLog = {
-				type: BALANCETYPE.WITHDRAW,
-				volume: changeValue,
-				status: STATUSTYPE.FINISHED,
-				bank,
-				bankAccount,
-				createdAt: new Date().getTime(),
-			};
-			await UserService.pushBalanceLog(userId, newBalanceLog);
-			res.status(200).json({ balance });
-		} catch (error) {
-			next(error);
-		}
-	});
+				const result = await UserService.updateBalance(userId, changeValue * -1);
+				const { balance } = result;
+
+				const newBalanceLog: IBalanceLog = {
+					type: BALANCETYPE.WITHDRAW,
+					volume: changeValue,
+					status: STATUSTYPE.FINISHED,
+					bank,
+					bankAccount,
+					createdAt: new Date().getTime(),
+				};
+				await UserService.pushBalanceLog(userId, newBalanceLog);
+				res.status(200).json({ balance });
+			} catch (error) {
+				next(error);
+			}
+		},
+	);
 
 	return router;
 };

--- a/back/src/api/user/favorite.ts
+++ b/back/src/api/user/favorite.ts
@@ -1,40 +1,41 @@
 import express, { NextFunction, Request, Response } from 'express';
 import { UserFavoriteService } from '@services/index';
 import { AuthError, AuthErrorMessage } from 'errors/index';
+import sessionValidator from '@api/middleware/sessionValidator';
 
 export default (): express.Router => {
 	const router = express.Router();
 
-	router.get('/favorite', async (req: Request, res: Response, next: NextFunction) => {
+	router.get('/favorite', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const userFavorite = await UserFavoriteService.getUserFavoriteByUserId(userId);
 			const favorite = userFavorite.map((elem) => elem.code);
+
 			res.status(200).json({ favorite });
 		} catch (error) {
 			next(error);
 		}
 	});
 
-	router.post('/favorite', async (req: Request, res: Response, next: NextFunction) => {
+	router.post('/favorite', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const { stockCode } = req.body;
 			await UserFavoriteService.createUserFavorite(userId, stockCode);
+
 			res.status(200).json({ code: stockCode });
 		} catch (error) {
 			next(error);
 		}
 	});
 
-	router.delete('/favorite', async (req: Request, res: Response, next: NextFunction) => {
+	router.delete('/favorite', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const { stockCode } = req.body;
 			await UserFavoriteService.removeUserFavorite(userId, stockCode);
+
 			res.status(200).json({ code: stockCode });
 		} catch (error) {
 			next(error);

--- a/back/src/api/user/hold.ts
+++ b/back/src/api/user/hold.ts
@@ -1,6 +1,7 @@
 import express, { NextFunction, Request, Response } from 'express';
 import { AuthError, AuthErrorMessage } from 'errors/index';
 import { UserStockService } from '@services/index';
+import sessionValidator from '@api/middleware/sessionValidator';
 
 export default (): express.Router => {
 	const router = express.Router();
@@ -19,6 +20,7 @@ export default (): express.Router => {
 					nameEnglish: elem.stock.nameEnglish,
 				};
 			});
+
 			res.status(200).json({ holdStocks });
 		} catch (error) {
 			next(error);

--- a/back/src/api/user/order.ts
+++ b/back/src/api/user/order.ts
@@ -3,43 +3,31 @@ import express, { NextFunction, Request, Response } from 'express';
 
 import { OrderService, UserService } from '@services/index';
 import Emitter from '@helper/eventEmitter';
-import { AuthError, AuthErrorMessage, ParamError, ParamErrorMessage } from 'errors/index';
+import { ParamError, ParamErrorMessage } from 'errors/index';
 import { orderValidator, stockIdValidator } from '@api/middleware/orderValidator';
 import config from '@config/index';
+import sessionValidator from '@api/middleware/sessionValidator';
 
 export default (): express.Router => {
 	const router = express.Router();
 
-	router.get('/order', async (req: Request, res: Response, next: NextFunction) => {
+	router.get('/order', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const { stockCode } = req.body;
 			const pendingOrder = await UserService.readPendingOrder(userId, stockCode);
+
 			res.status(200).json({ pendingOrder });
 		} catch (error) {
 			next(error);
 		}
 	});
 
-	router.post('/order', orderValidator, async (req: Request, res: Response, next: NextFunction) => {
+	router.post('/order', sessionValidator, orderValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const { stockCode, type, amount, price } = req.body;
-			if (
-				!stockCode ||
-				!type ||
-				!amount ||
-				!price ||
-				price <= 0 ||
-				price >= config.maxPrice ||
-				amount <= 0 ||
-				amount >= config.maxAmount
-			)
-				throw new ParamError(ParamErrorMessage.INVALID_PARAM);
 			await OrderService.order(userId, stockCode, type, amount, price);
-			fetch(`${process.env.AUCTIONEER_URL}/api/message/bid?code=${req.body.stockCode}`);
 
 			const acceptedOrderInfo = {
 				stockCode,
@@ -51,17 +39,18 @@ export default (): express.Router => {
 					},
 				},
 			};
-			Emitter.emit('order accepted', acceptedOrderInfo);
+
 			res.status(200).json({});
+			fetch(`${process.env.AUCTIONEER_URL}/api/message/bid?code=${req.body.stockCode}`);
+			Emitter.emit('order accepted', acceptedOrderInfo);
 		} catch (error) {
 			next(error);
 		}
 	});
 
-	router.delete('/order', async (req: Request, res: Response, next: NextFunction) => {
+	router.delete('/order', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const { id } = req.query;
 			if (!id) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
 			await OrderService.cancel(userId, Number(id));
@@ -71,22 +60,12 @@ export default (): express.Router => {
 		}
 	});
 
-	router.put('/order', async (req: Request, res: Response, next: NextFunction) => {
+	router.put('/order', sessionValidator, orderValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const { orderId, amount, price } = req.body;
-			if (
-				!orderId ||
-				!amount ||
-				!price ||
-				price <= 0 ||
-				price >= config.maxPrice ||
-				amount <= 0 ||
-				amount >= config.maxAmount
-			)
-				throw new ParamError(ParamErrorMessage.INVALID_PARAM);
 			await OrderService.modify(userId, orderId, amount, price);
+
 			res.status(200).json({});
 		} catch (error) {
 			next(error);
@@ -110,8 +89,6 @@ export default (): express.Router => {
 		try {
 			const { botId: userId, stockCode, type, amount, price } = req.body;
 			await OrderService.order(userId, stockCode, type, amount, price);
-			fetch(`${process.env.AUCTIONEER_URL}/api/message/bid?code=${req.body.stockCode}`);
-
 			const acceptedOrderInfo = {
 				stockCode,
 				msg: {
@@ -122,8 +99,10 @@ export default (): express.Router => {
 					},
 				},
 			};
-			Emitter.emit('order accepted', acceptedOrderInfo);
+
 			res.status(200).json({});
+			fetch(`${process.env.AUCTIONEER_URL}/api/message/bid?code=${req.body.stockCode}`);
+			Emitter.emit('order accepted', acceptedOrderInfo);
 		} catch (error) {
 			next(error);
 		}

--- a/back/src/api/user/transaction.ts
+++ b/back/src/api/user/transaction.ts
@@ -1,15 +1,16 @@
 import express, { NextFunction, Request, Response } from 'express';
-import { AuthError, AuthErrorMessage } from 'errors/index';
 import { UserService } from '@services/index';
+import sessionValidator from '@api/middleware/sessionValidator';
 
 export default (): express.Router => {
 	const router = express.Router();
-	router.get('/transaction', async (req: Request, res: Response, next: NextFunction) => {
+
+	router.get('/transaction', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const { type, start, end } = req.query;
 			const log = await UserService.readTransactionLog(userId, Number(start), Number(end), Number(type));
+
 			res.status(200).json({ log });
 		} catch (error) {
 			next(error);

--- a/back/src/api/user/user.ts
+++ b/back/src/api/user/user.ts
@@ -1,15 +1,16 @@
 import express, { NextFunction, Request, Response } from 'express';
-import { AuthError, AuthErrorMessage, ParamError, UserError } from '@errors/index';
+import { ParamError, UserError } from '@errors/index';
 import { UserService } from '@services/index';
+import sessionValidator from '@api/middleware/sessionValidator';
 
 export default (): express.Router => {
 	const router = express.Router();
 
-	router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+	router.get('/', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const user = await UserService.getUserById(userId);
+
 			res.status(200).json({ user });
 		} catch (error) {
 			next(error);
@@ -20,6 +21,7 @@ export default (): express.Router => {
 		try {
 			const { email } = req.query;
 			await UserService.getUserByEmail(String(email));
+
 			return res.status(200).json({ result: false });
 		} catch (error) {
 			if (error instanceof UserError) return res.status(200).json({ result: true });

--- a/back/src/loaders/socket.ts
+++ b/back/src/loaders/socket.ts
@@ -2,11 +2,9 @@ import wsModule from 'ws';
 import fs from 'fs';
 import _http from 'http';
 import _https from 'https';
-import { Application } from 'express';
 import Emitter from '@helper/eventEmitter';
 import { binArrayToJson, JsonToBinArray } from '@helper/tools';
 import { StockError, StockErrorMessage } from '@errors/index';
-import Logger from './logger';
 import { ISocketRequest } from '../interfaces/socketRequest';
 import StockService from '../services/StockService';
 

--- a/back/src/loaders/socket.ts
+++ b/back/src/loaders/socket.ts
@@ -117,7 +117,7 @@ export default async (): Promise<void> => {
 					const stockCode = requestData.stockCode ?? '';
 					const conclusions = await stockService.getConclusionByCode(stockCode);
 
-					ws.send(translateResponseFormat('baseStock', { conclusions, charts: [] }));
+					ws.send(translateResponseFormat('baseStock', { stockCode, conclusions }));
 					socketClientMap.set(ws, { ...socketClientMap.get(ws), target: stockCode });
 					break;
 				}

--- a/back/src/services/StockService.ts
+++ b/back/src/services/StockService.ts
@@ -71,7 +71,10 @@ export default class StockService {
 	}
 
 	public async getConclusionByCode(code: string): Promise<ITransactionLog[]> {
-		const conclusionsData = await TransactionLog.find({ stockCode: code }, { amount: 1, price: 1, createdAt: 1, _id: 1 })
+		const conclusionsData = await TransactionLog.find(
+			{ stockCode: code },
+			{ amount: 1, price: 1, createdAt: 1, _id: 1, stockCode: 1 },
+		)
 			.sort({ createdAt: -1 })
 			.limit(50);
 

--- a/front/src/pages/trade/conclusion/Conclusion.tsx
+++ b/front/src/pages/trade/conclusion/Conclusion.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { useRecoilValue } from 'recoil';
-import StockExecution from '@recoil/stockExecution/index';
+
 import './conclusion.scss';
 import Ticks from './Ticks';
 import Days from './Days';
@@ -17,16 +16,15 @@ interface Props {
 
 const Conclusion = ({ previousClose, stockCode }: Props) => {
 	const [tab, setTab] = useState(TAB.TICK);
-	const stockExecutionState = useRecoilValue(StockExecution);
 
 	const getCurrentTab = () => {
 		switch (tab) {
 			case TAB.TICK:
-				return <Ticks key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
+				return <Ticks key={tab} previousClose={previousClose} />;
 			case TAB.DAY:
 				return <Days key={tab} stockCode={stockCode} />;
 			default:
-				return <Ticks key={tab} stockExecutionState={stockExecutionState} previousClose={previousClose} />;
+				return <Ticks key={tab} previousClose={previousClose} />;
 		}
 	};
 

--- a/front/src/pages/trade/conclusion/Ticks.tsx
+++ b/front/src/pages/trade/conclusion/Ticks.tsx
@@ -36,10 +36,10 @@ const Ticks = (props: Props) => {
 				<div className="conclusion-total-price">체결금액(원)</div>
 			</header>
 			<div className="conclusion-content">
-				{stockExecutionState.length === 0 ? (
+				{stockExecutionState.executions.length === 0 ? (
 					<p className="conclusion-notice-no-data">체결 정보가 없습니다.</p>
 				) : (
-					stockExecutionState.map((log: IStockExecutionItem) => {
+					stockExecutionState.executions.map((log: IStockExecutionItem) => {
 						const [day, time] = translateTimestampFormat(log.timestamp).split(' ');
 						return (
 							<div className="conclusion-row" key={log.id}>

--- a/front/src/pages/trade/conclusion/Ticks.tsx
+++ b/front/src/pages/trade/conclusion/Ticks.tsx
@@ -1,8 +1,9 @@
 import { IStockExecutionItem } from '@src/recoil/stockExecution';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
+import StockExecution from '@recoil/stockExecution/index';
 
 interface Props {
-	stockExecutionState: IStockExecutionItem[];
 	previousClose: number;
 }
 
@@ -23,7 +24,9 @@ const colorPicker = (prev: number, current: number): string => {
 };
 
 const Ticks = (props: Props) => {
-	const { stockExecutionState, previousClose } = props;
+	const { previousClose } = props;
+	const stockExecutionState = useRecoilValue(StockExecution);
+
 	return (
 		<>
 			<header className="conclusion-header">

--- a/front/src/recoil/stockExecution/atom.ts
+++ b/front/src/recoil/stockExecution/atom.ts
@@ -5,12 +5,21 @@ export interface IStockExecutionItem {
 	price: number;
 	volume: number;
 	amount: number;
+	stockCode: string;
 	id: string;
 }
 
-const stockExecutionAtom = atom<IStockExecutionItem[]>({
+export interface IStockExecutionInfo {
+	stockCode: string;
+	executions: IStockExecutionItem[];
+}
+
+const stockExecutionAtom = atom<IStockExecutionInfo>({
 	key: 'stockExecutionAtom',
-	default: [],
+	default: {
+		stockCode: '',
+		executions: [],
+	},
 });
 
 export default stockExecutionAtom;


### PR DESCRIPTION
1. 체결 atom의 타입 구조를 변경하여 stockCode와 함께 체결 내역 배열을 갖도록 수정합니다
 - 새로운 체결 내역을 전달받으면 atom에 저장된 현재 종목의 코드를 확인하고 일치하면 추가합니다

2. backend의 API 라우터 로직 중 param, body data들에 대해 조건 검증 로직들을 미들웨어로 분리합니다.