### PR TITLE
hotfix:log validator 미들웨어 적용, 차트 날짜표기 오류 수정

### DIFF
--- a/back/src/api/middleware/logValidator.ts
+++ b/back/src/api/middleware/logValidator.ts
@@ -19,8 +19,6 @@ const logValidator = (req: Request, res: Response, next: NextFunction): void => 
 	} catch (error) {
 		next(error);
 	}
-
-	next();
 };
 
 export default logValidator;

--- a/back/src/api/stock/log.ts
+++ b/back/src/api/stock/log.ts
@@ -1,3 +1,4 @@
+import logValidator from '@api/middleware/logValidator';
 import ParamError, { ParamErrorMessage } from '@errors/ParamError';
 import { CHARTTYPE_VALUE } from '@interfaces/IChartLog';
 import StockService from '@services/StockService';
@@ -6,11 +7,11 @@ import express, { NextFunction, Request, Response } from 'express';
 export default (): express.Router => {
 	const router = express.Router();
 
-	router.get('/log', async (req: Request, res: Response, next: NextFunction) => {
+	router.get('/log', logValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
 			const { code, start, end, type } = res.locals;
 			const log = await StockService.getStockLog(code, type as CHARTTYPE_VALUE, start, end);
-
+			console.log(log);
 			res.status(200).json({ log });
 		} catch (error) {
 			next(error);

--- a/front/src/pages/trade/chart/period/PeriodLegend.tsx
+++ b/front/src/pages/trade/chart/period/PeriodLegend.tsx
@@ -22,7 +22,7 @@ interface IDrawPeriodLegendArgs {
 
 const formatPeriodLegend = (timestamp: number) => {
 	const date = new Date(timestamp);
-	const [mm, dd, yyyy] = date.toLocaleString().slice(0, 10).split('/');
+	const [mm, dd, yyyy] = date.toLocaleString('en').slice(0, 10).split('/');
 
 	return `${yyyy}-${mm}-${dd} ${formatCandleDate(timestamp)}`;
 };


### PR DESCRIPTION
log API에 logValidator가 적용이 누락되었던 부분을 수정합니다
타임존 차이로 toLocaleString에 '.' , '/' 구분 되던 현상을 수정합니다