### PR TITLE
feat: 주문 체결 시 주문 가능 수량 업데이트 로직 수정

### DIFF
--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import toast from 'react-hot-toast';
 import { SetterOrUpdater, useSetRecoilState } from 'recoil';
+import fetchHoldStocks from '@common/utils/fetchHoldStocks';
 import webSocketAtom from '@recoil/websocket/atom';
 import stockListAtom, { IStockListItem, IStockChartItem } from '@recoil/stockList/atom';
 import { IAskOrderItem, IBidOrderItem, askOrdersAtom, bidOrdersAtom } from '@recoil/stockOrders/index';
 import stockExecutionAtom, { IStockExecutionInfo, IStockExecutionItem } from './recoil/stockExecution/atom';
 import { translateRequestData, translateResponseData } from './common/utils/socketUtils';
-import fetchHoldStocks from '@common/utils/fetchHoldStocks';
 import Emitter from './common/utils/eventEmitter';
 import HoldStockListAtom from './recoil/holdStockList/atom';
-import { getHoldStocks } from './pages/trade/sideBar/refreshStockData';
 import dailyLogAtom, { IDailyLog } from './recoil/stockDailyLog/atom';
 import chartAtom, { IChartItem } from './recoil/chart/atom';
 

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -6,6 +6,7 @@ import stockListAtom, { IStockListItem, IStockChartItem } from '@recoil/stockLis
 import { IAskOrderItem, IBidOrderItem, askOrdersAtom, bidOrdersAtom } from '@recoil/stockOrders/index';
 import stockExecutionAtom, { IStockExecutionInfo, IStockExecutionItem } from './recoil/stockExecution/atom';
 import { translateRequestData, translateResponseData } from './common/utils/socketUtils';
+import fetchHoldStocks from '@common/utils/fetchHoldStocks';
 import Emitter from './common/utils/eventEmitter';
 import HoldStockListAtom from './recoil/holdStockList/atom';
 import { getHoldStocks } from './pages/trade/sideBar/refreshStockData';
@@ -253,8 +254,6 @@ const startSocket = ({
 
 					setStockList((prev) => updateTargetStock(prev, matchData, currentChart));
 					addNewExecution(setStockExecution, data.match);
-
-					Emitter.emit('order concluded', matchData.code);
 				}
 				break;
 			}
@@ -314,7 +313,10 @@ const startSocket = ({
 							<p>&nbsp;매도 주문 체결되었습니다.</p>
 						</>,
 					);
-				setHold(await getHoldStocks());
+
+				const holdStockList = await fetchHoldStocks();
+				Emitter.emit('order concluded', data.stockCode, holdStockList);
+				setHold(holdStockList.map((stock: { code: string }) => stock.code));
 				break;
 			}
 			default:

--- a/front/src/common/utils/fetchHoldStocks.ts
+++ b/front/src/common/utils/fetchHoldStocks.ts
@@ -1,0 +1,18 @@
+const fetchHoldStockList = async () => {
+	try {
+		const res = await fetch(`${process.env.SERVER_URL}/api/user/hold`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+			},
+		});
+		if (res.status !== 200) throw new Error();
+		const { holdStocks } = await res.json();
+		return holdStocks;
+	} catch (error) {
+		return [];
+	}
+};
+
+export default fetchHoldStockList;

--- a/front/src/common/utils/getAvailableAmount.ts
+++ b/front/src/common/utils/getAvailableAmount.ts
@@ -1,4 +1,4 @@
-interface IHoldStock {
+export interface IHoldStock {
 	amount: number;
 	average: number;
 	code: string;

--- a/front/src/pages/trade/bidAsk/BidAsk.tsx
+++ b/front/src/pages/trade/bidAsk/BidAsk.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import bidAskPriceAtom from '@src/recoil/bidAskPrice/atom';
 import toast from 'react-hot-toast';
-import { getUserAskAvailable, getUserBidAvailable } from '@common/utils/getAvailableAmount';
+import { IHoldStock, getUserAskAvailable, getUserBidAvailable } from '@common/utils/getAvailableAmount';
 import userAtom, { IUser } from '@recoil/user/atom';
 import Emitter from '@common/utils/eventEmitter';
 import BidAskType from './BidAskType';
@@ -30,9 +30,13 @@ const BidAsk = ({ stockCode }: { stockCode: string }) => {
 
 	const handleSetBidAskType = (newType: string) => setBidAskType(newType);
 
-	const setUserAvailableAmount = async (code: string, isSignedIn: boolean) => {
-		setAskAvailable(await getUserAskAvailable(code, isSignedIn));
+	const setUserAvailableAmount = async (code: string, isSignedIn: boolean, askAvailable: number | null = null) => {
 		setBidAvailable(await getUserBidAvailable(isSignedIn));
+		if (askAvailable) {
+			setAskAvailable(askAvailable);
+			return;
+		}
+		setAskAvailable(await getUserAskAvailable(code, isSignedIn));
 	};
 
 	const handleReset = () => {
@@ -103,8 +107,9 @@ const BidAsk = ({ stockCode }: { stockCode: string }) => {
 	};
 
 	useEffect(() => {
-		const listener = async (code: string) => {
-			setUserAvailableAmount(code, isLoggedIn);
+		const listener = async (stockCode: string, holdStockList: IHoldStock[]) => {
+			const [holdStock] = holdStockList.filter(({ code }) => code === stockCode);
+			setUserAvailableAmount('', isLoggedIn, holdStock.amount);
 		};
 
 		Emitter.on('order concluded', listener);


### PR DESCRIPTION
이전에는 유저별로 메시지를 보내는 기능이 구현되기 전이라 유저의 주문에 관계없이 시스템에서 체결이 될 때마다 서버에 요청을 날려서 주문가능 수량을 업데이트 했었습니다. 이를 유저가 넣은 주문이 체결되는 경우에만 업데이트 하도록 수정하였습니다.