### PR TITLE
1분/1일봉 로그 데이터 저장 로직 핫픽스

### DIFF
--- a/auctioneer/src/services/ScheduleService.ts
+++ b/auctioneer/src/services/ScheduleService.ts
@@ -6,6 +6,8 @@ import { ChartRepository } from '@repositories/index';
 import { getConnection } from 'typeorm';
 import fetch from 'node-fetch';
 
+const ONE_SEC_IN_MILLISECONDS = 1000;
+
 export default class ScheduleService {
 	reportNewChart(chartLogList: IChartLog[]): void {
 		fetch(`${process.env.API_SERVER_URL}/api/stock/chart/new`, {
@@ -28,7 +30,7 @@ export default class ScheduleService {
 			priceLow: chart.priceLow,
 			amount: chart.amount,
 			volume: chart.volume,
-			createdAt: new Date().getTime(),
+			createdAt: Date.now() - ONE_SEC_IN_MILLISECONDS * 30,
 		};
 		const chartLog = new ChartLog(log);
 		await chartLog.save();


### PR DESCRIPTION
- 1분/1일봉 로그 데이터가 mongodb에 저장될 때 `createdAt`의 값이 1분/하루씩 밀려서 저장되는 부분을 수정하였습니다.