### PR TITLE
[리팩토링] 소켓 로직 분리 및 이벤트 재정의

### DIFF
--- a/auctioneer/src/api/message/message.ts
+++ b/auctioneer/src/api/message/message.ts
@@ -11,7 +11,7 @@ export default (): express.Router => {
 		try {
 			const { code } = req.query;
 			if (code === undefined) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
-			eventEmitter.emit('waiting', code);
+			eventEmitter.emit('WAITING', code);
 			res.end();
 		} catch (error) {
 			next(error);

--- a/auctioneer/src/loaders/matchLogger.ts
+++ b/auctioneer/src/loaders/matchLogger.ts
@@ -21,7 +21,7 @@ const runAuctioneer = async (stockCode: string): Promise<void> => {
 	waitingSet[stockCode] = false;
 };
 
-EventEmitter.on('waiting', (stockCode: string): void => {
+EventEmitter.on('WAITING', (stockCode: string): void => {
 	if (waitingSet[stockCode]) return;
 	runAuctioneer(stockCode);
 });

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -38,6 +38,7 @@
                 "@types/jest": "^27.0.3",
                 "@types/node": "^16.11.7",
                 "@types/node-fetch": "^2.5.12",
+                "@types/ws": "^8.2.1",
                 "@typescript-eslint/eslint-plugin": "^4.33.0",
                 "@typescript-eslint/parser": "^4.33.0",
                 "better-sqlite3": "^7.4.5",
@@ -1901,6 +1902,15 @@
             "dependencies": {
                 "@types/node": "*",
                 "@types/webidl-conversions": "*"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.1.tgz",
+            "integrity": "sha512-SqQ+LhVZaJi7c7sYVkjWALDigi/Wy7h7Iu72gkQp8Y8OWw/DddEVBrTSKu86pQftV2+Gm8lYM61hadPKqyaIeg==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/yargs": {
@@ -13061,6 +13071,15 @@
             "requires": {
                 "@types/node": "*",
                 "@types/webidl-conversions": "*"
+            }
+        },
+        "@types/ws": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.1.tgz",
+            "integrity": "sha512-SqQ+LhVZaJi7c7sYVkjWALDigi/Wy7h7Iu72gkQp8Y8OWw/DddEVBrTSKu86pQftV2+Gm8lYM61hadPKqyaIeg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
             }
         },
         "@types/yargs": {

--- a/back/package.json
+++ b/back/package.json
@@ -24,6 +24,7 @@
         "@types/jest": "^27.0.3",
         "@types/node": "^16.11.7",
         "@types/node-fetch": "^2.5.12",
+        "@types/ws": "^8.2.1",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "better-sqlite3": "^7.4.5",

--- a/back/src/api/auth/github.ts
+++ b/back/src/api/auth/github.ts
@@ -22,7 +22,7 @@ export default (): express.Router => {
 				email: userInfo.email,
 			};
 
-			res.status(200).cookie('alarmToken', alarmToken).json({});
+			res.status(200).cookie('alarm_token', alarmToken).json({});
 			eventEmitter.emit('LOGIN_USER', userInfo.userId, alarmToken);
 		} catch (error) {
 			next(error);
@@ -42,7 +42,7 @@ export default (): express.Router => {
 				email: userInfo.email,
 			};
 
-			res.status(200).cookie('alarmToken', alarmToken).json({});
+			res.status(200).cookie('alarm_token', alarmToken).json({});
 			eventEmitter.emit('LOGIN_USER', userInfo.userId, alarmToken);
 		} catch (error) {
 			next(error);

--- a/back/src/api/auth/github.ts
+++ b/back/src/api/auth/github.ts
@@ -23,7 +23,7 @@ export default (): express.Router => {
 			};
 
 			res.status(200).cookie('alarmToken', alarmToken).json({});
-			eventEmitter.emit('loginUser', userInfo.userId, alarmToken);
+			eventEmitter.emit('LOGIN_USER', userInfo.userId, alarmToken);
 		} catch (error) {
 			next(error);
 		}
@@ -43,7 +43,7 @@ export default (): express.Router => {
 			};
 
 			res.status(200).cookie('alarmToken', alarmToken).json({});
-			eventEmitter.emit('loginUser', userInfo.userId, alarmToken);
+			eventEmitter.emit('LOGIN_USER', userInfo.userId, alarmToken);
 		} catch (error) {
 			next(error);
 		}

--- a/back/src/api/auth/signout.ts
+++ b/back/src/api/auth/signout.ts
@@ -12,7 +12,7 @@ export default (): express.Router => {
 		try {
 			const { alarmToken } = req.cookies;
 			res.clearCookie('connect.sid');
-			res.clearCookie('alarmToken');
+			res.clearCookie('alarm_token');
 			req.session.destroy(() => res.status(200).json({}));
 
 			eventEmitter.emit('LOGOUT', alarmToken);

--- a/back/src/api/auth/signout.ts
+++ b/back/src/api/auth/signout.ts
@@ -15,7 +15,7 @@ export default (): express.Router => {
 			res.clearCookie('alarmToken');
 			req.session.destroy(() => res.status(200).json({}));
 
-			eventEmitter.emit('logout', alarmToken);
+			eventEmitter.emit('LOGOUT', alarmToken);
 		} catch (error) {
 			next(error);
 		}

--- a/back/src/api/middleware/logValidator.ts
+++ b/back/src/api/middleware/logValidator.ts
@@ -15,6 +15,7 @@ const logValidator = (req: Request, res: Response, next: NextFunction): void => 
 		)
 			throw new ParamError(ParamErrorMessage.INVALID_PARAM);
 		res.locals = { code, start: Number(start), end: Number(end), type };
+
 		next();
 	} catch (error) {
 		next(error);

--- a/back/src/api/middleware/orderValidator.ts
+++ b/back/src/api/middleware/orderValidator.ts
@@ -68,7 +68,6 @@ export const balanceValidator = (req: Request, res: Response, next: NextFunction
 			throw new ParamError(ParamErrorMessage.INVALID_PARAM);
 		next();
 	} catch (err) {
-		console.log('validator');
 		next(err);
 	}
 };

--- a/back/src/api/stock/log.ts
+++ b/back/src/api/stock/log.ts
@@ -11,7 +11,7 @@ export default (): express.Router => {
 		try {
 			const { code, start, end, type } = res.locals;
 			const log = await StockService.getStockLog(code, type as CHARTTYPE_VALUE, start, end);
-			console.log(log);
+
 			res.status(200).json({ log });
 		} catch (error) {
 			next(error);

--- a/back/src/api/stock/stock.ts
+++ b/back/src/api/stock/stock.ts
@@ -16,9 +16,9 @@ export default (): express.Router => {
 
 		res.end();
 
-		Emitter.emit('broadcast', { stockCode, msg: broadcastMessage });
-		Emitter.emit('notice', bidUser, { userType: 'bid', stockCode });
-		Emitter.emit('notice', askUser, { userType: 'ask', stockCode });
+		Emitter.emit('BROADCAST', { stockCode, msg: broadcastMessage });
+		Emitter.emit('NOTICE', bidUser, { userType: 'bid', stockCode });
+		Emitter.emit('NOTICE', askUser, { userType: 'ask', stockCode });
 	});
 
 	router.post('/chart/new', async (req: Request, res: Response) => {
@@ -30,7 +30,7 @@ export default (): express.Router => {
 
 		res.end();
 
-		Emitter.emit('chart', stockChartJson);
+		Emitter.emit('CHART', stockChartJson);
 	});
 
 	router.get('/prices', async (req: Request, res: Response) => {

--- a/back/src/api/user/balance.ts
+++ b/back/src/api/user/balance.ts
@@ -15,6 +15,7 @@ export default (): express.Router => {
 			const result = await UserService.getUserById(userId);
 			const { balance } = result;
 			const log = await UserService.readBalanceLog(userId, Number(start), Number(end), Number(type));
+
 			res.status(200).json({ balance, log });
 		} catch (error) {
 			next(error);
@@ -41,6 +42,7 @@ export default (): express.Router => {
 					createdAt: new Date().getTime(),
 				};
 				await UserService.pushBalanceLog(userId, newBalanceLog);
+
 				res.status(200).json({ balance });
 			} catch (error) {
 				next(error);
@@ -69,6 +71,7 @@ export default (): express.Router => {
 					createdAt: new Date().getTime(),
 				};
 				await UserService.pushBalanceLog(userId, newBalanceLog);
+
 				res.status(200).json({ balance });
 			} catch (error) {
 				next(error);

--- a/back/src/api/user/hold.ts
+++ b/back/src/api/user/hold.ts
@@ -6,10 +6,9 @@ import sessionValidator from '@api/middleware/sessionValidator';
 export default (): express.Router => {
 	const router = express.Router();
 
-	router.get('/hold', async (req: Request, res: Response, next: NextFunction) => {
+	router.get('/hold', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const userId = req.session.data?.userId;
-			if (userId === undefined) throw new AuthError(AuthErrorMessage.INVALID_SESSION);
+			const { userId } = res.locals;
 			const result = await UserStockService.readUserStockWithStockInfo(userId);
 			const holdStocks = result.map((elem) => {
 				return {

--- a/back/src/api/user/order.ts
+++ b/back/src/api/user/order.ts
@@ -30,11 +30,9 @@ export default (): express.Router => {
 			const acceptedOrderInfo = {
 				stockCode,
 				msg: {
-					order: {
-						type,
-						amount,
-						price,
-					},
+					type,
+					amount,
+					price,
 				},
 			};
 

--- a/back/src/api/user/order.ts
+++ b/back/src/api/user/order.ts
@@ -1,11 +1,9 @@
 import fetch from 'node-fetch';
 import express, { NextFunction, Request, Response } from 'express';
-
 import { OrderService, UserService } from '@services/index';
 import Emitter from '@helper/eventEmitter';
 import { ParamError, ParamErrorMessage } from 'errors/index';
 import { orderValidator, stockIdValidator } from '@api/middleware/orderValidator';
-import config from '@config/index';
 import sessionValidator from '@api/middleware/sessionValidator';
 
 export default (): express.Router => {
@@ -42,7 +40,7 @@ export default (): express.Router => {
 
 			res.status(200).json({});
 			fetch(`${process.env.AUCTIONEER_URL}/api/message/bid?code=${req.body.stockCode}`);
-			Emitter.emit('order accepted', acceptedOrderInfo);
+			Emitter.emit('ACCEPTED_ORDER', acceptedOrderInfo);
 		} catch (error) {
 			next(error);
 		}
@@ -54,6 +52,7 @@ export default (): express.Router => {
 			const { id } = req.query;
 			if (!id) throw new ParamError(ParamErrorMessage.INVALID_PARAM);
 			await OrderService.cancel(userId, Number(id));
+
 			res.status(200).json({});
 		} catch (error) {
 			next(error);
@@ -102,7 +101,7 @@ export default (): express.Router => {
 
 			res.status(200).json({});
 			fetch(`${process.env.AUCTIONEER_URL}/api/message/bid?code=${req.body.stockCode}`);
-			Emitter.emit('order accepted', acceptedOrderInfo);
+			Emitter.emit('ACCEPTED_ORDER', acceptedOrderInfo);
 		} catch (error) {
 			next(error);
 		}

--- a/back/src/loaders/index.ts
+++ b/back/src/loaders/index.ts
@@ -15,4 +15,5 @@ export default async ({ expressApp }: { expressApp: Application }): Promise<void
 	await mongooseLoader();
 	Logger.info('✌️ Mongoose loaded');
 	webSocketLoader();
+	Logger.info('✌️ WebSocket loaded');
 };

--- a/back/src/loaders/socket.ts
+++ b/back/src/loaders/socket.ts
@@ -2,76 +2,11 @@ import wsModule from 'ws';
 import fs from 'fs';
 import _http from 'http';
 import _https from 'https';
-import Emitter from '@helper/eventEmitter';
-import { binArrayToJson, JsonToBinArray } from '@helper/tools';
-import { StockError, StockErrorMessage } from '@errors/index';
-import { ISocketRequest } from '../interfaces/socketRequest';
-import StockService from '../services/StockService';
-
-const loginUserMap = new Map();
-const socketClientMap = new Map();
-const socketAlarmMap = new Map();
-const translateRequestFormat = (data) => binArrayToJson(data);
-const translateResponseFormat = (type, data) => JsonToBinArray({ type, data });
-const getNemClientForm = () => {
-	return { target: '', alarmToken: '' };
-};
-
-const connectNewUser = async (client) => {
-	try {
-		const stockService = new StockService();
-		const stockList = await stockService.getStocksCurrent();
-
-		client.send(translateResponseFormat('stocksInfo', stockList));
-		socketClientMap.set(client, getNemClientForm());
-	} catch (error) {
-		throw new StockError(StockErrorMessage.CANNOT_READ_STOCK_LIST);
-	}
-};
-const disconnectUser = (client) => {
-	const { alarmToken } = socketClientMap.get(client);
-	const userId = loginUserMap.get(alarmToken);
-	socketAlarmMap.delete(userId);
-	socketClientMap.delete(client);
-};
-
-const logoutUserHandler = (alarmToken) => {
-	const logoutUser = loginUserMap.get(alarmToken);
-	const logoutSocket = socketAlarmMap.get(logoutUser);
-
-	loginUserMap.delete(alarmToken);
-	socketAlarmMap.delete(logoutUser);
-	socketClientMap.set(logoutSocket, { ...socketClientMap.get(logoutSocket), alarmToken: '' });
-};
-
-const broadcast = ({ stockCode, msg }) => {
-	socketClientMap.forEach(({ target: targetStockCode }, client) => {
-		if (targetStockCode === stockCode) {
-			// 모든 데이터 전송, 현재가, 호가, 차트 등...
-			client?.send(translateResponseFormat('updateTarget', msg));
-		} else {
-			// msg 오브젝트의 데이터에서 aside 바에 필요한 데이터만 골라서 전송
-			client?.send(translateResponseFormat('updateStock', msg.match));
-		}
-	});
-};
-
-const sendAlarmMessage = (userId, msg) => {
-	const client = socketAlarmMap.get(userId);
-	client?.send(translateResponseFormat('notice', msg));
-};
-
-const sendNewChart = (stockCharts) => {
-	socketClientMap.forEach(({ target: targetStockCode }, client) => {
-		if (!stockCharts[targetStockCode]) return;
-		client.send(translateResponseFormat('chart', stockCharts[targetStockCode]));
-	});
-};
+import setSocketEvent from '@services/SocketService';
 
 const startHttpServer = () => {
 	return _http.createServer();
 };
-
 const startHttpsServer = () => {
 	return _https.createServer({
 		ca: fs.readFileSync('/etc/ssl/ca_bundle.crt'),
@@ -80,59 +15,12 @@ const startHttpsServer = () => {
 	});
 };
 
-export default async (): Promise<void> => {
+export default (): void => {
 	const server = process.env.NODE_ENV === 'production' ? startHttpsServer() : startHttpServer();
 	const webSocketServer = new wsModule.WebSocketServer({ server });
+
+	webSocketServer['binaryType'] = 'arraybuffer';
 	server.listen(process.env.SOCKET_PORT || 3333);
 
-	webSocketServer.binaryType = 'arraybuffer';
-
-	const loginUser = (userId, alarmToken) => {
-		loginUserMap.set(alarmToken, userId);
-	};
-	const registerAlarmToken = (ws, alarmToken) => {
-		socketClientMap.set(ws, { ...socketClientMap.get(ws), alarmToken });
-		const userId = loginUserMap.get(alarmToken);
-		if (userId) socketAlarmMap.set(userId, ws);
-	};
-
-	Emitter.on('broadcast', broadcast);
-	Emitter.on('loginUser', loginUser);
-	Emitter.on('order accepted', broadcast);
-	Emitter.on('notice', sendAlarmMessage);
-	Emitter.on('chart', sendNewChart);
-
-	webSocketServer.on('connection', async (ws, req) => {
-		await connectNewUser(ws);
-
-		ws.on('message', async (message: string) => {
-			const requestData: ISocketRequest = translateRequestFormat(message);
-
-			switch (requestData.type) {
-				case 'open': {
-					if (!socketClientMap.has(ws)) return;
-					const stockService = new StockService();
-					const stockCode = requestData.stockCode ?? '';
-					const conclusions = await stockService.getConclusionByCode(stockCode);
-
-					ws.send(translateResponseFormat('baseStock', { stockCode, conclusions }));
-					socketClientMap.set(ws, { ...socketClientMap.get(ws), target: stockCode });
-					break;
-				}
-				case 'alarm': {
-					const { alarmToken } = requestData;
-					registerAlarmToken(ws, alarmToken);
-					break;
-				}
-				default:
-					ws.send(translateResponseFormat('error', '알 수 없는 오류가 발생했습니다.'));
-			}
-		});
-
-		ws.on('close', () => {
-			disconnectUser(ws);
-		});
-	});
+	setSocketEvent(webSocketServer);
 };
-
-Emitter.on('logout', logoutUserHandler);

--- a/back/src/services/SocketService.ts
+++ b/back/src/services/SocketService.ts
@@ -17,7 +17,7 @@ const connectNewUser = async (client) => {
 		const stockService = new StockService();
 		const stockList = await stockService.getStocksCurrent();
 
-		client.send(translateResponseFormat('stocksInfo', stockList));
+		client.send(translateResponseFormat('STOCKS_INFO', stockList));
 		socketClientMap.set(client, getNemClientForm());
 	} catch (error) {
 		throw new StockError(StockErrorMessage.CANNOT_READ_STOCK_LIST);
@@ -41,21 +41,21 @@ const broadcast = ({ stockCode, msg }) => {
 	socketClientMap.forEach(({ target: targetStockCode }, client) => {
 		if (targetStockCode === stockCode) {
 			// 모든 데이터 전송, 현재가, 호가, 차트 등...
-			client?.send(translateResponseFormat('updateTarget', msg));
+			client?.send(translateResponseFormat('UPDATE_TARGET', msg));
 		} else {
 			// msg 오브젝트의 데이터에서 aside 바에 필요한 데이터만 골라서 전송
-			client?.send(translateResponseFormat('updateStock', msg.match));
+			client?.send(translateResponseFormat('UPDATE_STOCK', msg.match));
 		}
 	});
 };
 const sendAlarmMessage = (userId, msg) => {
 	const client = socketAlarmMap.get(userId);
-	client?.send(translateResponseFormat('notice', msg));
+	client?.send(translateResponseFormat('NOTICE', msg));
 };
 const sendNewChart = (stockCharts) => {
 	socketClientMap.forEach(({ target: targetStockCode }, client) => {
 		if (!stockCharts[targetStockCode]) return;
-		client.send(translateResponseFormat('chart', stockCharts[targetStockCode]));
+		client.send(translateResponseFormat('CHART', stockCharts[targetStockCode]));
 	});
 };
 const loginUser = (userId, alarmToken) => {
@@ -81,7 +81,7 @@ export default (webSocketServer): void => {
 					const stockCode = requestData.stockCode ?? '';
 					const conclusions = await stockService.getConclusionByCode(stockCode);
 
-					ws.send(translateResponseFormat('baseStock', { stockCode, conclusions }));
+					ws.send(translateResponseFormat('BASE_STOCK', { stockCode, conclusions }));
 					socketClientMap.set(ws, { ...socketClientMap.get(ws), target: stockCode });
 					break;
 				}
@@ -91,7 +91,7 @@ export default (webSocketServer): void => {
 					break;
 				}
 				default:
-					ws.send(translateResponseFormat('error', '알 수 없는 오류가 발생했습니다.'));
+					ws.send(translateResponseFormat('ERROR', '알 수 없는 오류가 발생했습니다.'));
 			}
 		});
 
@@ -101,9 +101,9 @@ export default (webSocketServer): void => {
 	});
 };
 
-Emitter.on('broadcast', broadcast);
-Emitter.on('loginUser', loginUser);
-Emitter.on('order accepted', broadcast);
-Emitter.on('notice', sendAlarmMessage);
-Emitter.on('chart', sendNewChart);
-Emitter.on('logout', logoutUserHandler);
+Emitter.on('BROADCAST', broadcast);
+Emitter.on('LOGIN_USER', loginUser);
+Emitter.on('ACCEPTED_ORDER', broadcast);
+Emitter.on('NOTICE', sendAlarmMessage);
+Emitter.on('CHART', sendNewChart);
+Emitter.on('LOGOUT', logoutUserHandler);

--- a/back/src/services/SocketService.ts
+++ b/back/src/services/SocketService.ts
@@ -1,0 +1,109 @@
+import Emitter from '@helper/eventEmitter';
+import { binArrayToJson, JsonToBinArray } from '@helper/tools';
+import { StockError, StockErrorMessage } from '@errors/index';
+import { ISocketRequest } from '../interfaces/socketRequest';
+import StockService from '../services/StockService';
+
+const loginUserMap = new Map();
+const socketClientMap = new Map();
+const socketAlarmMap = new Map();
+const translateRequestFormat = (data) => binArrayToJson(data);
+const translateResponseFormat = (type, data) => JsonToBinArray({ type, data });
+const getNemClientForm = () => {
+	return { target: '', alarmToken: '' };
+};
+const connectNewUser = async (client) => {
+	try {
+		const stockService = new StockService();
+		const stockList = await stockService.getStocksCurrent();
+
+		client.send(translateResponseFormat('stocksInfo', stockList));
+		socketClientMap.set(client, getNemClientForm());
+	} catch (error) {
+		throw new StockError(StockErrorMessage.CANNOT_READ_STOCK_LIST);
+	}
+};
+const disconnectUser = (client) => {
+	const { alarmToken } = socketClientMap.get(client);
+	const userId = loginUserMap.get(alarmToken);
+	socketAlarmMap.delete(userId);
+	socketClientMap.delete(client);
+};
+const logoutUserHandler = (alarmToken) => {
+	const logoutUser = loginUserMap.get(alarmToken);
+	const logoutSocket = socketAlarmMap.get(logoutUser);
+
+	loginUserMap.delete(alarmToken);
+	socketAlarmMap.delete(logoutUser);
+	socketClientMap.set(logoutSocket, { ...socketClientMap.get(logoutSocket), alarmToken: '' });
+};
+const broadcast = ({ stockCode, msg }) => {
+	socketClientMap.forEach(({ target: targetStockCode }, client) => {
+		if (targetStockCode === stockCode) {
+			// 모든 데이터 전송, 현재가, 호가, 차트 등...
+			client?.send(translateResponseFormat('updateTarget', msg));
+		} else {
+			// msg 오브젝트의 데이터에서 aside 바에 필요한 데이터만 골라서 전송
+			client?.send(translateResponseFormat('updateStock', msg.match));
+		}
+	});
+};
+const sendAlarmMessage = (userId, msg) => {
+	const client = socketAlarmMap.get(userId);
+	client?.send(translateResponseFormat('notice', msg));
+};
+const sendNewChart = (stockCharts) => {
+	socketClientMap.forEach(({ target: targetStockCode }, client) => {
+		if (!stockCharts[targetStockCode]) return;
+		client.send(translateResponseFormat('chart', stockCharts[targetStockCode]));
+	});
+};
+const loginUser = (userId, alarmToken) => {
+	loginUserMap.set(alarmToken, userId);
+};
+const registerAlarmToken = (ws, alarmToken) => {
+	socketClientMap.set(ws, { ...socketClientMap.get(ws), alarmToken });
+	const userId = loginUserMap.get(alarmToken);
+	if (userId) socketAlarmMap.set(userId, ws);
+};
+
+export default (webSocketServer): void => {
+	webSocketServer.on('connection', async (ws, req) => {
+		await connectNewUser(ws);
+
+		ws.on('message', async (message: string) => {
+			const requestData: ISocketRequest = translateRequestFormat(message);
+
+			switch (requestData.type) {
+				case 'open': {
+					if (!socketClientMap.has(ws)) return;
+					const stockService = new StockService();
+					const stockCode = requestData.stockCode ?? '';
+					const conclusions = await stockService.getConclusionByCode(stockCode);
+
+					ws.send(translateResponseFormat('baseStock', { stockCode, conclusions }));
+					socketClientMap.set(ws, { ...socketClientMap.get(ws), target: stockCode });
+					break;
+				}
+				case 'alarm': {
+					const { alarmToken } = requestData;
+					registerAlarmToken(ws, alarmToken);
+					break;
+				}
+				default:
+					ws.send(translateResponseFormat('error', '알 수 없는 오류가 발생했습니다.'));
+			}
+		});
+
+		ws.on('close', () => {
+			disconnectUser(ws);
+		});
+	});
+};
+
+Emitter.on('broadcast', broadcast);
+Emitter.on('loginUser', loginUser);
+Emitter.on('order accepted', broadcast);
+Emitter.on('notice', sendAlarmMessage);
+Emitter.on('chart', sendNewChart);
+Emitter.on('logout', logoutUserHandler);

--- a/back/src/services/SocketService.ts
+++ b/back/src/services/SocketService.ts
@@ -48,6 +48,12 @@ const broadcast = ({ stockCode, msg }) => {
 		}
 	});
 };
+const sendOrderMessage = ({ stockCode, msg }) => {
+	socketClientMap.forEach(({ target: targetStockCode }, client) => {
+		if (targetStockCode !== stockCode) return;
+		client?.send(translateResponseFormat('ORDER', msg));
+	});
+};
 const sendAlarmMessage = (userId, msg) => {
 	const client = socketAlarmMap.get(userId);
 	client?.send(translateResponseFormat('NOTICE', msg));
@@ -103,7 +109,7 @@ export default (webSocketServer): void => {
 
 Emitter.on('BROADCAST', broadcast);
 Emitter.on('LOGIN_USER', loginUser);
-Emitter.on('ACCEPTED_ORDER', broadcast);
+Emitter.on('ACCEPTED_ORDER', sendOrderMessage);
 Emitter.on('NOTICE', sendAlarmMessage);
 Emitter.on('CHART', sendNewChart);
 Emitter.on('LOGOUT', logoutUserHandler);

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -245,8 +245,6 @@ const startSocket = ({
 
 				setStockList((prev) => updateTargetStock(prev, matchData, currentChart));
 				addNewExecution(setStockExecution, data.match);
-
-				Emitter.emit('order concluded', matchData.code);
 				break;
 			}
 			case 'ORDER': {
@@ -313,7 +311,7 @@ const startSocket = ({
 					);
 
 				const holdStockList = await fetchHoldStocks();
-				Emitter.emit('order concluded', data.stockCode, holdStockList);
+				Emitter.emit('CONCLUDED_ORDER', data.stockCode, holdStockList);
 				setHold(holdStockList.map((stock: { code: string }) => stock.code));
 				break;
 			}

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -227,41 +227,40 @@ const startSocket = ({
 	webSocket.onmessage = async (event) => {
 		const { type, data } = translateResponseData(event.data);
 		switch (type) {
-			case 'stocksInfo': {
+			case 'STOCKS_INFO': {
 				setStockList(data);
 				break;
 			}
-			case 'updateStock': {
+			case 'UPDATE_STOCK': {
 				if (!data) return;
 				setStockList((prev) => updateNonTargetStock(prev, data));
 				break;
 			}
-			case 'updateTarget': {
-				const { match: matchData, currentChart, order, bidAsk } = data;
-				// 주문 접수 케이스
-				if (order) {
-					if (order.type === 1) setAskOrders((prev) => updateOrdersAfterAcceptOrder(prev, order) as IAskOrderItem[]);
-					else setBidOrders((prev) => updateOrdersAfterAcceptOrder(prev, order) as IBidOrderItem[]);
-				}
+			case 'UPDATE_TARGET': {
+				const { match: matchData, currentChart, bidAsk } = data;
+				const { askOrders, bidOrders }: { askOrders: IAskOrderItem[]; bidOrders: IBidOrderItem[] } = bidAsk;
 
-				// 주문 체결 케이스
-				if (matchData && currentChart) {
-					const { askOrders, bidOrders }: { askOrders: IAskOrderItem[]; bidOrders: IBidOrderItem[] } = bidAsk;
+				setAskOrders(() => updateAskOrders(askOrders));
+				setBidOrders(() => updateBidOrders(bidOrders));
 
-					setAskOrders(() => updateAskOrders(askOrders));
-					setBidOrders(() => updateBidOrders(bidOrders));
+				setStockList((prev) => updateTargetStock(prev, matchData, currentChart));
+				addNewExecution(setStockExecution, data.match);
 
-					setStockList((prev) => updateTargetStock(prev, matchData, currentChart));
-					addNewExecution(setStockExecution, data.match);
-				}
+				Emitter.emit('order concluded', matchData.code);
 				break;
 			}
-			case 'baseStock': {
+			case 'ORDER': {
+				const { type } = data;
+				if (type === 1) setAskOrders((prev) => updateOrdersAfterAcceptOrder(prev, data) as IAskOrderItem[]);
+				else setBidOrders((prev) => updateOrdersAfterAcceptOrder(prev, data) as IBidOrderItem[]);
+				break;
+			}
+			case 'BASE_STOCK': {
 				const stockExecutionForm = { stockCode: data.stockCode, executions: dataToExecutionForm(data.conclusions) };
 				setStockExecution(stockExecutionForm);
 				break;
 			}
-			case 'chart': {
+			case 'CHART': {
 				if (data.type === 1440) {
 					const { _id: id, priceEnd, amount, createdAt } = data;
 					setDailyLog((prev) => [{ _id: id, priceEnd, amount, createdAt }, ...prev]);
@@ -293,7 +292,7 @@ const startSocket = ({
 
 				break;
 			}
-			case 'notice': {
+			case 'NOTICE': {
 				if (data.userType === 'bid')
 					toast.success(
 						<>

--- a/front/src/Socket.tsx
+++ b/front/src/Socket.tsx
@@ -320,7 +320,8 @@ const startSocket = ({
 			default:
 		}
 	};
-	Emitter.on('registerAlarm', (alarmToken: string) => {
+
+	Emitter.on('REGISTER_ALARM', (alarmToken: string) => {
 		const alarmData = {
 			type: 'alarm',
 			alarmToken,

--- a/front/src/app.tsx
+++ b/front/src/app.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => {
 						email: data.user.email,
 						isLoggedIn: true,
 					});
-					eventEmitter.emit('registerAlarm', getCookie('alarmToken'));
+					eventEmitter.emit('REGISTER_ALARM', getCookie('alarm_token'));
 				});
 			}
 		});

--- a/front/src/pages/signIn/SignIn.tsx
+++ b/front/src/pages/signIn/SignIn.tsx
@@ -36,7 +36,7 @@ const SignIn = () => {
 		}).then(async (res: Response) => {
 			if (res.ok) {
 				await res.json();
-				eventEmitter.emit('registerAlarm', getCookie('alarmToken'));
+				eventEmitter.emit('REGISTER_ALARM', getCookie('alarm_token'));
 				setUserState({ ...userState, isLoggedIn: true });
 				history.push('/');
 				toast.success('성공적으로 로그인 되었습니다.');

--- a/front/src/pages/signUp/SignUp.tsx
+++ b/front/src/pages/signUp/SignUp.tsx
@@ -62,7 +62,7 @@ const SignUp = () => {
 			body: JSON.stringify({ code: query.get('code'), username, email }),
 		}).then((res: Response) => {
 			if (res.ok) {
-				eventEmitter.emit('registerAlarm', getCookie('alarmToken'));
+				eventEmitter.emit('REGISTER_ALARM', getCookie('alarm_token'));
 				setUserState({ ...userState, isLoggedIn: true });
 				toast.success('성공적으로 회원가입 되었습니다.');
 				history.push('/');

--- a/front/src/pages/trade/bidAsk/BidAsk.tsx
+++ b/front/src/pages/trade/bidAsk/BidAsk.tsx
@@ -112,10 +112,10 @@ const BidAsk = ({ stockCode }: { stockCode: string }) => {
 			setUserAvailableAmount('', isLoggedIn, holdStock.amount);
 		};
 
-		Emitter.on('order concluded', listener);
+		Emitter.on('CONCLUDED_ORDER', listener);
 
 		return () => {
-			Emitter.off('order concluded', listener);
+			Emitter.off('CONCLUDED_ORDER', listener);
 		};
 	}, [isLoggedIn]);
 


### PR DESCRIPTION
1. backend의 소켓 로직을 loader, service 로직으로 분리합니다.
2. frontend의 주문 정보 로직을 하나의 케이스로 분리합니다.
3. Event Emitter의 이벤트 이름과 소켓 전송 데이터의 type을 대문자, '_' 로 재정의합니다. (ex.BASE_STOCK)
4. 클라이언트에 저장되는 쿠키 중 알람토큰의 이름을 위와 같은 규칙으로 재정의합니다.