### PR TITLE
[리팩토링] 체결내역, 주문내역에 인피니티 스크롤 적용

### DIFF
--- a/back/src/api/user/order.ts
+++ b/back/src/api/user/order.ts
@@ -12,8 +12,8 @@ export default (): express.Router => {
 	router.get('/order', sessionValidator, async (req: Request, res: Response, next: NextFunction) => {
 		try {
 			const { userId } = res.locals;
-			const { stockCode } = req.body;
-			const pendingOrder = await UserService.readPendingOrder(userId, stockCode);
+			const { end } = req.query;
+			const pendingOrder = await UserService.readPendingOrder(userId, Number(end));
 
 			res.status(200).json({ pendingOrder });
 		} catch (error) {

--- a/back/src/services/UserService.ts
+++ b/back/src/services/UserService.ts
@@ -1,16 +1,7 @@
 /* eslint-disable class-methods-use-this */
-import { EntityManager, getCustomRepository } from 'typeorm';
-import { OrderRepository, SessionRepository, StockRepository, UserRepository } from '@repositories/index';
-import {
-	CommonError,
-	CommonErrorMessage,
-	ParamError,
-	ParamErrorMessage,
-	StockError,
-	StockErrorMessage,
-	UserError,
-	UserErrorMessage,
-} from '@errors/index';
+import { EntityManager, getCustomRepository, LessThan } from 'typeorm';
+import { OrderRepository, SessionRepository, UserRepository } from '@repositories/index';
+import { CommonError, CommonErrorMessage, ParamError, ParamErrorMessage, UserError, UserErrorMessage } from '@errors/index';
 import { User, UserBalance, IBalanceLog, TransactionLog, ITransactionLog, ORDERTYPE } from '@models/index';
 
 interface IUserInfo {
@@ -97,35 +88,16 @@ export default class UserService {
 		sessions.map((elem) => sessionRepository.delete(elem));
 	}
 
-	static async readPendingOrder(userId: number, stockCode: string): Promise<unknown> {
+	static async readPendingOrder(userId: number, end: number): Promise<unknown> {
 		const orderRepository = getCustomRepository(OrderRepository);
-		const stockRepository = getCustomRepository(StockRepository);
-		if (stockCode) {
-			const stock = await stockRepository.findOne({ where: { code: stockCode } });
-			if (stock === undefined) throw new StockError(StockErrorMessage.NOT_EXIST_STOCK);
-			const orders = await orderRepository.find({
-				select: ['orderId', 'type', 'amount', 'price', 'createdAt'],
-				where: { userId, stockId: stock.stockId },
-				order: { createdAt: 'ASC' },
-			});
-
-			return orders.map((elem) => {
-				return {
-					orderId: elem.orderId,
-					stockCode,
-					type: elem.type,
-					amount: elem.amount,
-					price: elem.price,
-					createdAt: elem.createdAt,
-				};
-			});
-		}
 		const orders = await orderRepository.find({
 			select: ['orderId', 'type', 'amount', 'price', 'createdAt'],
-			where: { userId },
-			order: { createdAt: 'ASC' },
+			where: { userId, orderId: LessThan(end > 0 ? end : Number.MAX_SAFE_INTEGER) },
+			order: { orderId: 'DESC' },
 			relations: ['stock'],
+			take: 30,
 		});
+
 		return orders.map((elem) => {
 			return {
 				orderId: elem.orderId,
@@ -147,14 +119,16 @@ export default class UserService {
 				.or([{ bidUserId: userId }, { askUserId: userId }])
 				.gte('createdAt', start)
 				.lt('createdAt', end)
-				.sort('createdAt');
+				.sort({ createdAt: -1 })
+				.limit(30);
 		}
 		document = await TransactionLog.find()
 			.select('-_id -__v -transactionId')
 			.or([{ bidUserId: userId }, { askUserId: userId }])
 			.gte('createdAt', start)
 			.lt('createdAt', end)
-			.sort('createdAt');
+			.sort({ createdAt: -1 })
+			.limit(30);
 		return document.map((elem) => {
 			return {
 				stockCode: elem.stockCode,

--- a/front/src/pages/my/Orders.tsx
+++ b/front/src/pages/my/Orders.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, LegacyRef } from 'react';
 import toast from 'react-hot-toast';
 import toDateString from '@src/common/utils/toDateString';
 import { useRecoilValue } from 'recoil';
 import StockList, { IStockListItem } from '@src/recoil/stockList';
+import useInfinityScroll from './useInfinityScroll';
 
 import './Orders.scss';
 
@@ -23,22 +24,28 @@ interface IOrder {
 	orderAmount: number;
 }
 
-const Orders = () => {
-	const stockList = useRecoilValue<IStockListItem[]>(StockList);
-	const [orders, setOrders] = useState<IOrder[]>([]);
+const refresh = (
+	stockList: IStockListItem[],
+	orders: IOrder[],
+	setOrders: React.Dispatch<React.SetStateAction<IOrder[]>>,
+	setLoading: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+	setLoading(true);
 
-	const refresh = () => {
-		fetch(`${process.env.SERVER_URL}/api/user/order`, {
-			method: 'GET',
-			credentials: 'include',
-			headers: {
-				'Content-Type': 'application/json; charset=utf-8',
-			},
-		}).then((res: Response) => {
-			if (res.ok) {
-				res.json().then((data) => {
-					setOrders(
-						data.pendingOrder.map(
+	const id = orders[orders.length - 1]?.orderId || 0;
+	fetch(`${process.env.SERVER_URL}/api/user/order?end=${id}`, {
+		method: 'GET',
+		credentials: 'include',
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+		},
+	}).then((res: Response) => {
+		if (res.ok) {
+			res.json()
+				.then((data) => {
+					setOrders((prev) => [
+						...prev,
+						...data.pendingOrder.map(
 							(order: {
 								orderId: number;
 								stockCode: string;
@@ -59,30 +66,36 @@ const Orders = () => {
 								};
 							},
 						),
-					);
+					]);
+				})
+				.finally(() => {
+					setLoading(false);
 				});
-			}
-		});
-	};
+		} else {
+			setLoading(false);
+		}
+	});
+};
 
-	const cancel = (orderId: number) => {
-		fetch(`${process.env.SERVER_URL}/api/user/order?id=${orderId}`, {
-			method: 'DELETE',
-			credentials: 'include',
-			headers: {
-				'Content-Type': 'application/json;charset=utf-8',
-			},
-		}).then((res: Response) => {
-			if (res.ok) toast.success('주문이 취소되었습니다.');
-			else toast.error('주문이 취소하지 못했습니다. 잠시후 재시도해주세요.');
+const cancel = (orderId: number, setOrders: React.Dispatch<React.SetStateAction<IOrder[]>>) => {
+	fetch(`${process.env.SERVER_URL}/api/user/order?id=${orderId}`, {
+		method: 'DELETE',
+		credentials: 'include',
+		headers: {
+			'Content-Type': 'application/json;charset=utf-8',
+		},
+	}).then((res: Response) => {
+		if (res.ok) toast.success('주문이 취소되었습니다.');
+		else toast.error('주문이 취소하지 못했습니다. 잠시후 재시도해주세요.');
 
-			refresh();
-		});
-	};
+		setOrders((prev) => [...prev.filter((order) => order.orderId !== orderId)]);
+	});
+};
 
-	useEffect(() => {
-		refresh();
-	}, []);
+const Orders = () => {
+	const stockList = useRecoilValue<IStockListItem[]>(StockList);
+	const [orders, setOrders] = useState<IOrder[]>([]);
+	const [rootRef, targetRef, loading] = useInfinityScroll(refresh.bind(undefined, stockList, orders, setOrders));
 
 	const getOrder = (order: IOrder) => {
 		let status = 'my__item-center';
@@ -101,7 +114,7 @@ const Orders = () => {
 				<td className="my__item-number">{order.price.toLocaleString()}</td>
 				<td className="my__item-number">{order.orderAmount.toLocaleString()}</td>
 				<td className="my__item-center">
-					<button className="cancel-order-btn" type="button" onClick={() => cancel(order.orderId)}>
+					<button className="cancel-order-btn" type="button" onClick={() => cancel(order.orderId, setOrders)}>
 						주문취소
 					</button>
 				</td>
@@ -121,12 +134,17 @@ const Orders = () => {
 					<th className="my__legend-center">&nbsp;</th>
 				</tr>
 			</thead>
-			<tbody className="my-order-items">
+			<tbody className="my-order-items" ref={rootRef as LegacyRef<HTMLTableSectionElement>}>
 				{orders.length > 0 ? (
 					orders.map((order: IOrder) => getOrder(order))
 				) : (
 					<tr className="my__item">
 						<td className="my__item-center">주문 내역이 없습니다.</td>
+					</tr>
+				)}
+				{loading === false && (
+					<tr className="my__item" ref={targetRef as LegacyRef<HTMLTableRowElement>}>
+						<td className="my__item-center" />
 					</tr>
 				)}
 			</tbody>

--- a/front/src/pages/my/Orders.tsx
+++ b/front/src/pages/my/Orders.tsx
@@ -73,8 +73,8 @@ const refresh = (
 	});
 };
 
-const cancel = (orderId: number, setOrders: React.Dispatch<React.SetStateAction<IOrder[]>>) => {
-	fetch(`${process.env.SERVER_URL}/api/user/order?id=${orderId}`, {
+const cancel = (orderId: number, orderType: ORDERTYPE, setOrders: React.Dispatch<React.SetStateAction<IOrder[]>>) => {
+	fetch(`${process.env.SERVER_URL}/api/user/order?id=${orderId}&type=${orderType}`, {
 		method: 'DELETE',
 		credentials: 'include',
 		headers: {
@@ -110,7 +110,11 @@ const Orders = () => {
 				<td className="my__item-number">{order.price.toLocaleString()}</td>
 				<td className="my__item-number">{order.orderAmount.toLocaleString()}</td>
 				<td className="my__item-center">
-					<button className="cancel-order-btn" type="button" onClick={() => cancel(order.orderId, setOrders)}>
+					<button
+						className="cancel-order-btn"
+						type="button"
+						onClick={() => cancel(order.orderId, order.orderType, setOrders)}
+					>
 						주문취소
 					</button>
 				</td>

--- a/front/src/pages/my/Orders.tsx
+++ b/front/src/pages/my/Orders.tsx
@@ -41,38 +41,34 @@ const refresh = (
 		},
 	}).then((res: Response) => {
 		if (res.ok) {
-			res.json()
-				.then((data) => {
-					setOrders((prev) => [
-						...prev,
-						...data.pendingOrder.map(
-							(order: {
-								orderId: number;
-								stockCode: string;
-								nameKorean: string;
-								type: ORDERTYPE;
-								amount: number;
-								price: number;
-								createdAt: number;
-							}) => {
-								return {
-									orderId: order.orderId,
-									orderTime: new Date(order.createdAt).getTime() + 32400000,
-									orderType: order.type,
-									stockCode: order.stockCode,
-									stockName: stockList.find((stock) => stock.code === order.stockCode)?.nameKorean,
-									price: order.price,
-									orderAmount: order.amount,
-								};
-							},
-						),
-					]);
-				})
-				.finally(() => {
-					setLoading(false);
-				});
-		} else {
-			setLoading(false);
+			res.json().then((data) => {
+				setOrders((prev) => [
+					...prev,
+					...data.pendingOrder.map(
+						(order: {
+							orderId: number;
+							stockCode: string;
+							nameKorean: string;
+							type: ORDERTYPE;
+							amount: number;
+							price: number;
+							createdAt: number;
+						}) => {
+							return {
+								orderId: order.orderId,
+								orderTime: new Date(order.createdAt).getTime() + 32400000,
+								orderType: order.type,
+								stockCode: order.stockCode,
+								stockName: stockList.find((stock) => stock.code === order.stockCode)?.nameKorean,
+								price: order.price,
+								orderAmount: order.amount,
+							};
+						},
+					),
+				]);
+
+				if (data.pendingOrder.length > 0) setLoading(false);
+			});
 		}
 	});
 };

--- a/front/src/pages/my/Transactions.tsx
+++ b/front/src/pages/my/Transactions.tsx
@@ -42,30 +42,26 @@ const refresh = (
 		},
 	}).then((res: Response) => {
 		if (res.ok) {
-			res.json()
-				.then((data) => {
-					setTransactions((prev) => [
-						...prev,
-						...data.log.map(
-							(log: { type: number; amount: number; createdAt: number; price: number; stockCode: string }) => {
-								return {
-									transactionTime: log.createdAt,
-									orderType: log.type,
-									stockCode: log.stockCode,
-									stockName: stockList.find((stock) => stock.code === log.stockCode)?.nameKorean,
-									price: log.price,
-									amount: log.amount,
-									volume: log.price * log.amount,
-								};
-							},
-						),
-					]);
-				})
-				.finally(() => {
-					setLoading(false);
-				});
-		} else {
-			setLoading(false);
+			res.json().then((data) => {
+				setTransactions((prev) => [
+					...prev,
+					...data.log.map(
+						(log: { type: number; amount: number; createdAt: number; price: number; stockCode: string }) => {
+							return {
+								transactionTime: log.createdAt,
+								orderType: log.type,
+								stockCode: log.stockCode,
+								stockName: stockList.find((stock) => stock.code === log.stockCode)?.nameKorean,
+								price: log.price,
+								amount: log.amount,
+								volume: log.price * log.amount,
+							};
+						},
+					),
+				]);
+
+				if (data.log.length > 0) setLoading(false);
+			});
 		}
 	});
 };

--- a/front/src/pages/my/useInfinityScroll.ts
+++ b/front/src/pages/my/useInfinityScroll.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect, useRef } from 'react';
+
+const onScroll = (refresh: () => void, entries: IntersectionObserverEntry[]) => {
+	entries.forEach((entry) => {
+		if (entry.isIntersecting) {
+			refresh();
+		}
+	});
+};
+
+export default function useInfinityScroll(callback: (setLoading: React.Dispatch<React.SetStateAction<boolean>>) => void) {
+	const rootRef = useRef<HTMLElement>(null);
+	const targetRef = useRef<HTMLElement>(null);
+	const [loading, setLoading] = useState<boolean>(false);
+
+	useEffect(() => {
+		let observer: IntersectionObserver;
+
+		if (targetRef.current) {
+			const boundRefresh = callback.bind(undefined, setLoading);
+			const boundOnScroll = onScroll.bind(undefined, boundRefresh);
+			observer = new IntersectionObserver(boundOnScroll, { root: rootRef.current, threshold: 0.5 });
+			observer.observe(targetRef.current);
+		}
+
+		return () => observer && observer.disconnect();
+	}, [loading]);
+
+	return [rootRef, targetRef, loading];
+}


### PR DESCRIPTION
## 관련 이슈
- #183 

## 내용
이슈에서 언급된 대로, 체결 내역과 주문 내역이 많으면 로딩이 될때까지 오래 대기해야 합니다.
Intersection Observer를 사용하여 스크롤을 최하단으로 내릴 때마다 조금씩 추가적으로 데이터를 가져오도록 수정하였습니다.