### PR TITLE
Hotfix: useChart 수정, useToasterStore 제거 등

### DIFF
--- a/front/src/app.tsx
+++ b/front/src/app.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import * as ReactDOM from 'react-dom';
 import { RecoilRoot, useRecoilState } from 'recoil';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
-import toast, { Toaster, useToasterStore } from 'react-hot-toast';
+import { Toaster } from 'react-hot-toast';
 import User from '@recoil/user';
 import TopBar from '@common/topbar/TopBar';
 import Theme from './Theme';
@@ -22,10 +22,7 @@ export interface Ipage {
 	title: string;
 }
 
-const TOAST_LIMIT = 3;
-
 const App: React.FC = () => {
-	const { toasts } = useToasterStore();
 	const [userState, setUserState] = useRecoilState(User);
 	const pages: Ipage[] = [];
 
@@ -50,13 +47,6 @@ const App: React.FC = () => {
 			}
 		});
 	}, []);
-
-	useEffect(() => {
-		toasts
-			.filter((t) => t.visible) // Only consider visible toasts
-			.filter((_, i) => i >= TOAST_LIMIT) // Is toast index over limit
-			.forEach((t) => toast.dismiss(t.id)); // Dismiss – Use toast.remove(t.id) removal without animation
-	}, [toasts]);
 
 	return (
 		<BrowserRouter>

--- a/front/src/common/topbar/TopBar.tsx
+++ b/front/src/common/topbar/TopBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import Logo from '@common/logo/Logo';
-import { Ipage } from '@src/app';
+import { Ipage } from '@src/App';
 import Menu from './menu/Menu';
 import ModeSwitch from './modeSwitch/ModeSwitch';
 

--- a/front/src/common/topbar/menu/Menu.tsx
+++ b/front/src/common/topbar/menu/Menu.tsx
@@ -3,7 +3,7 @@ import { Link, NavLink } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import toast from 'react-hot-toast';
 import userAtom from '@recoil/user';
-import { Ipage } from '@src/app';
+import { Ipage } from '@src/App';
 import UserIcon from './UserIcon';
 
 import './menu.scss';

--- a/front/src/pages/balance/Deposit.tsx
+++ b/front/src/pages/balance/Deposit.tsx
@@ -97,7 +97,7 @@ const Deposit = (props: DepositProps) => {
 					type="text"
 					id="balance"
 					name="balance"
-					maxLength={13}
+					maxLength={9}
 					value={balance}
 					onChange={changeBalance}
 				/>

--- a/front/src/pages/balance/Withdrawal.tsx
+++ b/front/src/pages/balance/Withdrawal.tsx
@@ -97,7 +97,7 @@ const Withdrawal = (props: WithdrawalProps) => {
 					type="text"
 					id="balance"
 					name="balance"
-					maxLength={13}
+					maxLength={9}
 					value={balance}
 					onChange={changeBalance}
 				/>

--- a/front/src/pages/trade/chart/hooks/useChart.tsx
+++ b/front/src/pages/trade/chart/hooks/useChart.tsx
@@ -57,8 +57,8 @@ const useChart = ({ stockState, stockCode, chartType }: IProps) => {
 			createdAt: Date.now(),
 			priceStart: targetChart.priceStart,
 			priceEnd: targetChart.priceEnd,
-			priceLow: targetChart.priceHigh,
-			priceHigh: targetChart.priceLow,
+			priceLow: targetChart.priceLow,
+			priceHigh: targetChart.priceHigh,
 			amount: targetChart.amount,
 		};
 


### PR DESCRIPTION
- `useChart` 에서 `priceLow`와 `priceHigh`의 위치가 서로 뒤바껴있는 부분을 수정하였습니다.
- 한 번에 뜨는 토스트 메시지의 개수를 제한하려고 사용한 `useToasterStore`로 인해 토스트 메시지가 뜰 때마다 `App` 컴포넌트가 리렌더링 되는 이슈가 있었습니다. 일단은 이를 제거하고 다른 라이브러리로 갈아탈 예정입니다.
- 최대 입/출금 금액을 제한하였습니다.